### PR TITLE
[내부개선] useRequest에서 데이터 바로 받도록 개선

### DIFF
--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -32,7 +32,7 @@ export const UserProvider = ({children}: {children: ReactNode}) => {
 
     const value = useMemo(
         () => ({
-            user: user,
+            user,
             reset() {
                 refreshUser()
             },

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,6 +1,7 @@
 import {User} from '$types/response/user'
 import {createContext, ReactNode, useContext, useMemo} from 'react'
 import useRequest from 'hooks/useRequest'
+import useAsyncError from '$hooks/useAsyncError'
 
 interface UserContextState {
     user: User | undefined
@@ -29,6 +30,11 @@ export const UserProvider = ({children}: {children: ReactNode}) => {
             revalidateOnMount: true,
         },
     )
+
+    const throwError = useAsyncError()
+    if (error) {
+        throwError(error)
+    }
 
     const value = useMemo(
         () => ({

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -6,6 +6,7 @@ interface UserContextState {
     user: User | undefined
     reset: (args?: User) => void
     isLoading?: boolean
+    error?: Error
 }
 
 export const UserContext = createContext<UserContextState>(
@@ -13,7 +14,11 @@ export const UserContext = createContext<UserContextState>(
 )
 
 export const UserProvider = ({children}: {children: ReactNode}) => {
-    const {data: user, mutate: refreshUser} = useRequest<User>(
+    const {
+        data: user,
+        error,
+        mutate: refreshUser,
+    } = useRequest<User>(
         {
             url: '/user',
             params: {
@@ -27,12 +32,14 @@ export const UserProvider = ({children}: {children: ReactNode}) => {
 
     const value = useMemo(
         () => ({
-            user: user?.result,
+            user: user,
             reset() {
                 refreshUser()
             },
+            isLoading: !user,
+            error,
         }),
-        [user, refreshUser],
+        [user, refreshUser, error],
     )
 
     return <UserContext.Provider value={value}>{children}</UserContext.Provider>

--- a/src/hooks/useRequest.ts
+++ b/src/hooks/useRequest.ts
@@ -1,30 +1,27 @@
 import {RequestConfig} from '$types/request'
 import {Response} from '$types/response'
-import {withAxios} from '$utils/fetcher/withAxios'
+import {createResponse, withAxios} from '$utils/fetcher/withAxios'
 import {AxiosError, AxiosResponse} from 'axios'
 import useSWR, {SWRConfiguration, SWRResponse} from 'swr'
 
 interface SwrReturn<Data, Error>
     extends Pick<
-        SWRResponse<AxiosResponse<Data>, AxiosError<Error>>,
+        SWRResponse<Data, AxiosError<Error>>,
         'isValidating' | 'revalidate' | 'error' | 'mutate'
     > {
     data: Data | undefined
-    response: AxiosResponse<Data> | undefined
+    response: Data | undefined
 }
 
 export interface SwrConfig<Data = unknown, Error = unknown>
-    extends Omit<
-        SWRConfiguration<AxiosResponse<Data>, AxiosError<Error>>,
-        'initialData'
-    > {
+    extends Omit<SWRConfiguration<Data, AxiosError<Error>>, 'initialData'> {
     initialData?: Data
 }
 
 export default function useRequest<Data = unknown, Error = unknown>(
     request: RequestConfig,
-    {initialData, ...config}: SwrConfig<Response<Data>, Error> = {},
-): SwrReturn<Response<Data>, Error> {
+    {initialData, ...config}: SwrConfig<Data, Error> = {},
+): SwrReturn<Data, Error> {
     const {
         data: response,
         error,
@@ -36,18 +33,19 @@ export default function useRequest<Data = unknown, Error = unknown>(
         () => withAxios<Data>(request),
         {
             ...config,
-            initialData: initialData && {
-                status: 200,
-                statusText: 'init',
-                config: request!,
-                headers: {},
-                data: initialData,
-            },
+            // initialData: initialData && {
+            //     status: 200,
+            //     statusText: 'init',
+            //     config: request!,
+            //     headers: {},
+            //     data: initialData,
+            // },
+            initialData,
         },
     )
 
     return {
-        data: response && response.data,
+        data: response,
         response,
         error,
         isValidating,

--- a/src/hooks/useRequest.ts
+++ b/src/hooks/useRequest.ts
@@ -1,7 +1,6 @@
 import {RequestConfig} from '$types/request'
-import {Response} from '$types/response'
-import {createResponse, withAxios} from '$utils/fetcher/withAxios'
-import {AxiosError, AxiosResponse} from 'axios'
+import {withAxios} from '$utils/fetcher/withAxios'
+import {AxiosError} from 'axios'
 import useSWR, {SWRConfiguration, SWRResponse} from 'swr'
 
 interface SwrReturn<Data, Error>
@@ -33,13 +32,6 @@ export default function useRequest<Data = unknown, Error = unknown>(
         () => withAxios<Data>(request),
         {
             ...config,
-            // initialData: initialData && {
-            //     status: 200,
-            //     statusText: 'init',
-            //     config: request!,
-            //     headers: {},
-            //     data: initialData,
-            // },
             initialData,
         },
     )

--- a/src/utils/fetcher/AuthInterceptor.ts
+++ b/src/utils/fetcher/AuthInterceptor.ts
@@ -6,9 +6,7 @@ import {CommonApiError, RedirectArror} from './ApiError'
 /**
  * @todo 회원 인증 에러 추가
  */
-export function AuthInterceptor<T>(
-    res: AxiosResponse<Response<T>>,
-): AxiosResponse {
+export function AuthInterceptor<T>(res: AxiosResponse<Response<T>>): T {
     const code = res.data.code
 
     if (code === RESPONSE.ERROR) {
@@ -19,5 +17,5 @@ export function AuthInterceptor<T>(
         throw new RedirectArror()
     }
 
-    return res
+    return res.data.result
 }

--- a/src/utils/fetcher/withAxios.ts
+++ b/src/utils/fetcher/withAxios.ts
@@ -2,7 +2,7 @@ import {RESPONSE} from '$constants'
 import {RequestConfig} from '$types/request'
 import {Response} from '$types/response'
 import {isSSR} from '$utils/env'
-import axios, {AxiosResponse} from 'axios'
+import axios from 'axios'
 import {HOST_URL} from 'config'
 import {AuthInterceptor} from './AuthInterceptor'
 

--- a/src/utils/fetcher/withAxios.ts
+++ b/src/utils/fetcher/withAxios.ts
@@ -12,13 +12,11 @@ export const createResponse = <T>(data: T): Response<T> => ({
     result: data,
 })
 
-export const withAxios = async <T>(
-    request: RequestConfig,
-): Promise<AxiosResponse<Response<T>>> => {
+export const withAxios = async <T>(request: RequestConfig): Promise<T> => {
     const instance = axios.create()
     instance.interceptors.response.use(AuthInterceptor)
 
-    const response = await instance.request({
+    const response = await instance.request<T, T>({
         ...request!,
         baseURL: `${isSSR ? HOST_URL : ''}/api`, // be에서 url 논의 필요
     })


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#24

### 작업 분류

-   [ ] 버그 수정
-   [ ] 신규 기능
-   [x] 프로젝트 구조 변경

### 작업 상세 내용
`withAxios`에서 저희가 정의했던 Response 타입 그대로를 반환하게 하니까 useSWR의 데이터도 `AxiosResponse<Response<Data>>`가 되었습니다.
```js
{
  code: '00' | '99',
  message: '',
  result: {} // 실데이터
}
```
따라서 useRequest또한 AxiosResponse로 받게 되어 intitialData 설정 시 `createResponse`로 한번 감싸줘야 하는등 번거로웠습니다.

이것을 실데이터만을 반환하도록 수정하였습니다.

#### as-is
```js
const {data: user, error, mutate} = useRequest<User>({
  url: '/user'
}, {
  initialData: createResponse(initialData)
})

const {code, result} = user // user의 Type이 Response

const value = {
  user: result // result가 User Type의 실데이터
}
```


#### to-be
```js
const {data: user, error, mutate} = useRequest<User>({
  url: '/user'
}, {
  initialData
})

const value = {
  user // user 자체가 실데이터
}

...
```
