### PR TITLE
메인화면 문구 수정, 로그아웃 이후 /profile API 호출 버그 수정

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -115,7 +115,7 @@ const MainHeader = ({logined, logout}: {logined: boolean; logout: () => void}) =
                                         <span style={{marginRight: '1.7rem'}}>💬</span>자주 묻는 질문
                                     </>
                                 ),
-                                link: ROUTES.COVID.SIDE.FAQ,
+                                link: '#', // 외부링크
                             },
                             {
                                 title: (
@@ -123,7 +123,7 @@ const MainHeader = ({logined, logout}: {logined: boolean; logout: () => void}) =
                                         <span style={{marginRight: '1.7rem'}}>💡</span>서비스 피드백
                                     </>
                                 ),
-                                link: ROUTES.COVID.SIDE.REVIEW,
+                                link: '#', // 외부링크
                             },
                             ...logoutValue,
                         ]}

--- a/src/components/main/LoginedWelcomeArea.tsx
+++ b/src/components/main/LoginedWelcomeArea.tsx
@@ -37,12 +37,8 @@ const LoginedWelcomeArea = ({email, name}: LoginedWelcomeAreaProps) => {
             <Email>
                 <span>{email}</span>
             </Email>
-            <Title>안녕하세요. {name}님.</Title>
-            <WelcomeText>
-                오늘도 나에게 편지를
-                <br />
-                남겨볼까요?
-            </WelcomeText>
+            <Title>안녕, 나야!</Title>
+            <WelcomeText>오늘도 편지를 남겨볼까?</WelcomeText>
         </Container>
     )
 }

--- a/src/components/main/MyLetterSection.tsx
+++ b/src/components/main/MyLetterSection.tsx
@@ -51,7 +51,7 @@ const MyLetterSection = ({logined}: {logined: boolean}) => {
                 <span>
                     나에게 <Highlight>00 통의 편지</Highlight>를
                     <br />
-                    작성했습니다!
+                    작성했어!
                 </span>
             </Title>
             <LetterButton>편지 목록 보기</LetterButton>

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -8,8 +8,6 @@ const ROUTES = Object.freeze({
         MAIN: `${THEME_COVID_PATH}`,
         SIDE: {
             ABOUT: `${THEME_COVID_PATH}/about`,
-            FAQ: `${THEME_COVID_PATH}/faq`,
-            REVIEW: `${THEME_COVID_PATH}/review`,
         },
         LETTER: {
             LIST: `${THEME_COVID_PATH}/letter`, // 메인에서 편지목록 더보기 눌렀을때 넘어오는 페이지

--- a/src/contexts/ProfileContext.tsx
+++ b/src/contexts/ProfileContext.tsx
@@ -25,6 +25,7 @@ export const ProfileProvider = ({children, token}: {children: ReactNode; token?:
         {
             revalidateOnMount: !!token,
             shouldRetryOnError: false,
+            initialData: token ? undefined : ({} as User),
         },
     )
 

--- a/src/hooks/useRequest.ts
+++ b/src/hooks/useRequest.ts
@@ -4,10 +4,7 @@ import {AxiosError} from 'axios'
 import useSWR, {SWRConfiguration, SWRResponse} from 'swr'
 
 interface SwrReturn<Data, Error>
-    extends Pick<
-        SWRResponse<Data, AxiosError<Error>>,
-        'isValidating' | 'revalidate' | 'error' | 'mutate'
-    > {
+    extends Pick<SWRResponse<Data, AxiosError<Error>>, 'isValidating' | 'revalidate' | 'error' | 'mutate'> {
     data: Data | undefined
     response: Data | undefined
 }
@@ -16,6 +13,8 @@ export interface SwrConfig<Data = unknown, Error = unknown>
     extends Omit<SWRConfiguration<Data, AxiosError<Error>>, 'initialData'> {
     initialData?: Data
 }
+
+const retrieveData = <Data = unknown>(data: Data) => new Promise<Data>((resolve) => resolve(data))
 
 export default function useRequest<Data = unknown, Error = unknown>(
     request: RequestConfig,
@@ -29,7 +28,7 @@ export default function useRequest<Data = unknown, Error = unknown>(
         mutate,
     } = useSWR(
         request && JSON.stringify(request),
-        () => withAxios<Data>(request),
+        () => (initialData ? retrieveData(initialData) : withAxios<Data>(request)),
         {
             ...config,
             initialData,

--- a/src/pages/covid/index.tsx
+++ b/src/pages/covid/index.tsx
@@ -90,23 +90,23 @@ const Main = ({
         setIsLogined(false)
         if (!isMobile) {
             alert({
-                title: '로그아웃되었습니다.',
+                title: '로그아웃 됐어. 다시 돌아올거지?',
             })
         } else {
-            toast('로그아웃되었습니다.', 1500)
+            toast('로그아웃 됐어. 다시 돌아올거지?', 1500)
         }
     }
 
     const createNewLetter = () => {
         if (!isLogined) {
             confirm({
-                title: '앗! 당황하셨죠?',
-                message: '이 기능은 로그인을 해야\n사용할 수 있는 기능입니다.\n로그인 하시겠어요?',
+                title: '앗! 당황했어?',
+                message: '이 기능은 로그인을 해야\n사용할 수 있는 기능이야!\n로그인할래?',
                 onSuccess: () => {
                     router.push(ROUTES.LOGIN)
                 },
-                successText: '네.할래요!',
-                cancelText: '아니요.안할래요',
+                successText: '응, 할래!',
+                cancelText: '아니, 안할래',
             })
         }
     }
@@ -119,13 +119,13 @@ const Main = ({
                     <Title>
                         <Highlight>총 {numberFormat(unsented + sented)}통</Highlight>의 편지가
                         <br />
-                        작성되었어요.
+                        작성되었어!
                     </Title>
                 </TitleContainer>
                 <SubTitle>
                     코로나가 끝나는 그 날,
                     <br />
-                    마음을 담은 편지를 전달해줄게요.
+                    마음을 담은 편지를 전달해줄게:)
                 </SubTitle>
                 <MainImage>
                     <SvgHome />
@@ -176,7 +176,7 @@ const Main = ({
                     style={{
                         marginTop: '1.6rem',
                     }}
-                    title="이만큼 작성됐어요"
+                    title="이만큼 작성됐어!"
                     info={[
                         {
                             title: '미발송 편지',

--- a/src/pages/covid/index.tsx
+++ b/src/pages/covid/index.tsx
@@ -108,7 +108,9 @@ const Main = ({
                 successText: '응, 할래!',
                 cancelText: '아니, 안할래',
             })
+            return
         }
+        router.push(ROUTES.COVID.LETTER.OPTION)
     }
 
     return (

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -78,7 +78,11 @@ const Login = ({isMobile}: {isMobile: boolean}) => {
                 <br />
                 ‘코로나’편
             </Title>
-            <SubTitle>어려운 시기, 미래의 나에게 마음을 담아 전해요.</SubTitle>
+            <SubTitle>
+                안녕, 나야! 어려운 시기,
+                <br />
+                미래의 나에게 마음을 담아 전해줘.
+            </SubTitle>
             <BottomFixed isMobile={isMobile}>
                 <Img>
                     <SvgLogin />
@@ -87,10 +91,15 @@ const Login = ({isMobile}: {isMobile: boolean}) => {
                     <IntroTitle>온전히 나에게 집중하는 시간...</IntroTitle>
                     <IntroContent isMobile={isMobile}>
                         이 서비스는 시끄러운 외부 환경에서 벗어나 스스로를 돌아보고 돌볼 수 있는 시간을 제공하는
-                        플랫폼이에요. 삶에 대한 깊이있는 질문에 답하기를 통해 자신의 생각을 정리하고 오직 자신에게
-                        집중하는 순간을 느껴보세요. 세상에 너무 많은 정보와 네트워킹이 범람하는 요즘, 많은 사람들이
-                        인생에서 가장 중요한 것은 바로 자신이라는 사실을 잊어버리곤 한답니다. 나에게 쓰는 편지는 이처럼
-                        가장 소중한 자신을 이해하고 알아가는 과정을 제시해줍니다.
+                        플랫폼이야.
+                        <br />
+                        삶에 대한 깊이있는 질문에 답하기를 통해 자신의 생각을 정리하고 오직 자신에게 집중하는 순간을
+                        느껴봐.
+                        <br />
+                        세상에 너무 많은 정보와 네트워킹이 범람하는 요즘, 많은 사람들이 인생에서 가장 중요한 것은 바로
+                        자신이라는 사실을 잊어버리곤 해.
+                        <br />
+                        나에게 쓰는 편지는 이처럼 가장 소중한 자신을 이해하고 알아가는 과정을 제시해줘.
                     </IntroContent>
                     <ButtonContainer isMobile={isMobile}>
                         <NaverLoginButton returnUrl={ROUTES.COVID.MAIN} isMobile={isMobile} />


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#60

### 작업 분류

-   [x] 버그 수정
-   [ ] 신규 기능
-   [ ] 프로젝트 구조 변경

### 작업 상세 내용

- 8/14 수정된 문구를 메인화면에 반영합니다.


### 🐛 Critical 에러 해결

현상 : 로그아웃 후 로그인 화면으로 이동 시 `/profile` API가 호출되어 401 에러를 받습니다.

#### 원인
1.`_app.tsx`의 `<ProfileContext>`는 props로 token(쿠키에 저장된 값)을 받음
2. 로그아웃 시 `Main` 컴포넌트에서 쿠키의 token을 제거
3. 그러나 `<ProfileContext>`는 아직 모름 (쿠키 변화 감지 x)
4. 다시 로그인 화면으로 이동했을 때 token props 갱신 (by `getInitialProps`)
5. `<ProfileContext>`가 리렌더링되면서 useRequest 재호출 (`token === undefined`이므로 401에러)
  - (주의) `revalidateOnMount`는 마운트시점에만 관여하고 리렌더링에는 `revalidateOnMount`여부와 관계없이 무조건 호출하는걸 확인 ㅠ

#### 해결
- `intialData` 값을 활용
  - token props가 없으면 `initialData` 설정
https://github.com/Nexters/covid-letter-web/blob/c7fb473e4e520e9965ed0af3ab4b64430277da00/src/contexts/ProfileContext.tsx#L28

  - `useRequest`의 fetcher에서 인자로 받은 initialData가 있으면 단순히 initialData를 리턴하도록 수정 (httpRequest X)
https://github.com/Nexters/covid-letter-web/blob/c7fb473e4e520e9965ed0af3ab4b64430277da00/src/hooks/useRequest.ts#L31