### PR TITLE
메인 헤더 및 사이드바 구조 개선

### DIFF
--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -1,5 +1,3 @@
-import SidebarButtonList from '$components/main/SidebarButtonList'
-import Sidebar from '$components/sidebar'
 import ROUTES from '$constants/routes'
 import {css} from '@emotion/react'
 import styled from '@emotion/styled'
@@ -7,10 +5,7 @@ import SvgSidemenu from 'assets/IconSideMenu'
 import {useRouter} from 'next/router'
 import {useState} from 'react'
 import tw from 'twin.macro'
-import WelcomeArea from '$components/main/WelcomeArea'
-import {SidebarButton} from '$components/main/types'
-import {useProfileContext} from '$contexts/ProfileContext'
-import LoginedWelcomeArea from '$components/main/LoginedWelcomeArea'
+import MainSidebar from '$components/main/MainSidebar'
 
 const HeaderWrapper = tw.div`tw-flex tw-flex-wrap tw-justify-between tw-items-center`
 const HeaderLeft = tw.div`tw-flex tw-items-center tw-truncate`
@@ -48,10 +43,6 @@ const Button = styled.button`
     box-shadow: none;
 `
 
-const SidebarContainer = styled.div`
-    padding: 3.2rem 0;
-`
-
 const LeftButtonList = () => {
     const router = useRouter()
     return (
@@ -68,27 +59,11 @@ type Props = {
 }
 
 const MainHeader = ({logined, logout}: Props) => {
-    const {profile} = useProfileContext()
-
     const [sidebarShow, setSidebarShow] = useState(false)
 
     const openSidebar = () => setSidebarShow(true)
     const closeSidebar = () => setSidebarShow(false)
-    const logoutValue: SidebarButton[] = logined
-        ? [
-              {
-                  title: (
-                      <>
-                          <span style={{marginRight: '1.7rem'}}>🏃</span>로그아웃
-                      </>
-                  ),
-                  onClick: () => {
-                      closeSidebar()
-                      logout()
-                  },
-              },
-          ]
-        : []
+
     return (
         <>
             <HeaderContainer>
@@ -103,40 +78,7 @@ const MainHeader = ({logined, logout}: Props) => {
                     </HeaderRight>
                 </HeaderWrapper>
             </HeaderContainer>
-            <Sidebar isShow={sidebarShow} closeFn={closeSidebar}>
-                <SidebarContainer>
-                    {logined && profile ? <LoginedWelcomeArea email={profile.email as string} /> : <WelcomeArea />}
-                    <SidebarButtonList
-                        list={[
-                            {
-                                title: (
-                                    <>
-                                        <span style={{marginRight: '1.7rem'}}>👋</span>안녕, 나야 소개
-                                    </>
-                                ),
-                                link: ROUTES.COVID.SIDE.ABOUT,
-                            },
-                            {
-                                title: (
-                                    <>
-                                        <span style={{marginRight: '1.7rem'}}>💬</span>자주 묻는 질문
-                                    </>
-                                ),
-                                link: '#', // 외부링크
-                            },
-                            {
-                                title: (
-                                    <>
-                                        <span style={{marginRight: '1.7rem'}}>💡</span>서비스 피드백
-                                    </>
-                                ),
-                                link: '#', // 외부링크
-                            },
-                            ...logoutValue,
-                        ]}
-                    />
-                </SidebarContainer>
-            </Sidebar>
+            <MainSidebar isShow={sidebarShow} closeFn={closeSidebar} logined={logined} logout={logout} />
         </>
     )
 }

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -3,9 +3,7 @@ import {css} from '@emotion/react'
 import styled from '@emotion/styled'
 import SvgSidemenu from 'assets/IconSideMenu'
 import {useRouter} from 'next/router'
-import {useState} from 'react'
 import tw from 'twin.macro'
-import MainSidebar from '$components/main/MainSidebar'
 
 const HeaderWrapper = tw.div`tw-flex tw-flex-wrap tw-justify-between tw-items-center`
 const HeaderLeft = tw.div`tw-flex tw-items-center tw-truncate`
@@ -69,16 +67,10 @@ const LeftButtonList = () => {
 }
 
 type Props = {
-    logined: boolean
-    logout: () => void
+    openSidebar: () => void
 }
 
-const MainHeader = ({logined, logout}: Props) => {
-    const [sidebarShow, setSidebarShow] = useState(false)
-
-    const openSidebar = () => setSidebarShow(true)
-    const closeSidebar = () => setSidebarShow(false)
-
+const MainHeader = ({openSidebar}: Props) => {
     return (
         <>
             <HeaderContainer>
@@ -93,7 +85,6 @@ const MainHeader = ({logined, logout}: Props) => {
                     </HeaderRight>
                 </HeaderWrapper>
             </HeaderContainer>
-            <MainSidebar isShow={sidebarShow} closeFn={closeSidebar} logined={logined} logout={logout} />
         </>
     )
 }

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -51,7 +51,7 @@ const LeftButtonList = () => {
         },
         {
             text: '부치지 못한 편지',
-            link: ROUTES.COVID.LETTER.LIST,
+            link: ROUTES.COVID.LETTER.LIST, // 인혁님 브랜치에서 수정 부탁드려요 :)
         },
     ]
     const router = useRouter()

--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -44,11 +44,26 @@ const Button = styled.button`
 `
 
 const LeftButtonList = () => {
+    const buttonList = [
+        {
+            text: '홈',
+            link: ROUTES.COVID.MAIN,
+        },
+        {
+            text: '부치지 못한 편지',
+            link: ROUTES.COVID.LETTER.LIST,
+        },
+    ]
     const router = useRouter()
+    const goLink = (link: string) => router.push(link)
+
     return (
         <div css={titleButtonCss}>
-            <Button className={router.pathname === ROUTES.COVID.MAIN ? 'active' : ''}>홈</Button>
-            <Button className={router.pathname === ROUTES.COVID.LETTER.LIST ? 'active' : ''}>부치지 못한 편지</Button>
+            {buttonList.map(({text, link}) => (
+                <Button key={text} className={router.pathname === link ? 'active' : ''} onClick={() => goLink(link)}>
+                    {text}
+                </Button>
+            ))}
         </div>
     )
 }

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,0 +1,5 @@
+const MainLayout = () => {
+    return <></>
+}
+
+export default MainLayout

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,4 +1,6 @@
 import MainHeader from '$components/header/MainHeader'
+import MainSidebar from '$components/main/MainSidebar'
+import {useState} from 'react'
 import {PropsWithChildren} from 'react'
 
 type MainLayoutProps = {
@@ -7,10 +9,16 @@ type MainLayoutProps = {
 }
 
 const MainLayout = ({children, logined, logout}: PropsWithChildren<MainLayoutProps>) => {
+    const [sidebarShow, setSidebarShow] = useState(false)
+
+    const openSidebar = () => setSidebarShow(true)
+    const closeSidebar = () => setSidebarShow(false)
+
     return (
         <>
-            <MainHeader logined={logined} logout={logout} />
+            <MainHeader openSidebar={openSidebar} />
             {children}
+            <MainSidebar isShow={sidebarShow} closeFn={closeSidebar} logined={logined} logout={logout} />
         </>
     )
 }

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,5 +1,18 @@
-const MainLayout = () => {
-    return <></>
+import MainHeader from '$components/header/MainHeader'
+import {PropsWithChildren} from 'react'
+
+type MainLayoutProps = {
+    logined: boolean
+    logout: () => void
+}
+
+const MainLayout = ({children, logined, logout}: PropsWithChildren<MainLayoutProps>) => {
+    return (
+        <>
+            <MainHeader logined={logined} logout={logout} />
+            {children}
+        </>
+    )
 }
 
 export default MainLayout

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,24 +1,44 @@
 import MainHeader from '$components/header/MainHeader'
 import MainSidebar from '$components/main/MainSidebar'
+import toast from '$components/toast'
+import {useAlertStore} from '$contexts/StoreContext'
+import useLogout from '$hooks/useLogout'
 import {useState} from 'react'
 import {PropsWithChildren} from 'react'
 
 type MainLayoutProps = {
     logined: boolean
-    logout: () => void
+    isMobile: boolean
+    isGoogleLogin: boolean
+    clear: () => void
 }
 
-const MainLayout = ({children, logined, logout}: PropsWithChildren<MainLayoutProps>) => {
+const MainLayout = ({children, logined, isMobile, isGoogleLogin, clear}: PropsWithChildren<MainLayoutProps>) => {
     const [sidebarShow, setSidebarShow] = useState(false)
 
     const openSidebar = () => setSidebarShow(true)
     const closeSidebar = () => setSidebarShow(false)
 
+    const logout = useLogout(isGoogleLogin)
+    const {alert} = useAlertStore()
+
+    const logoutPage = () => {
+        logout()
+        clear()
+        if (!isMobile) {
+            alert({
+                title: '로그아웃 됐어. 다시 돌아올거지?',
+            })
+        } else {
+            toast('로그아웃 됐어. 다시 돌아올거지?', 1500)
+        }
+    }
+
     return (
         <>
             <MainHeader openSidebar={openSidebar} />
             {children}
-            <MainSidebar isShow={sidebarShow} closeFn={closeSidebar} logined={logined} logout={logout} />
+            <MainSidebar isShow={sidebarShow} closeFn={closeSidebar} logined={logined} logout={logoutPage} />
         </>
     )
 }

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,30 +1,31 @@
 import MainHeader from '$components/header/MainHeader'
 import MainSidebar from '$components/main/MainSidebar'
 import toast from '$components/toast'
-import {useAlertStore} from '$contexts/StoreContext'
+import {useAlertStore, useAuthStore} from '$contexts/StoreContext'
 import useLogout from '$hooks/useLogout'
+import {observer} from 'mobx-react-lite'
 import {useState} from 'react'
 import {PropsWithChildren} from 'react'
 
 type MainLayoutProps = {
-    logined: boolean
     isMobile: boolean
     isGoogleLogin: boolean
-    clear: () => void
 }
 
-const MainLayout = ({children, logined, isMobile, isGoogleLogin, clear}: PropsWithChildren<MainLayoutProps>) => {
+const MainLayout = ({children, isMobile, isGoogleLogin}: PropsWithChildren<MainLayoutProps>) => {
     const [sidebarShow, setSidebarShow] = useState(false)
 
     const openSidebar = () => setSidebarShow(true)
     const closeSidebar = () => setSidebarShow(false)
+
+    const {isLogined, clearUser} = useAuthStore()
 
     const logout = useLogout(isGoogleLogin)
     const {alert} = useAlertStore()
 
     const logoutPage = () => {
         logout()
-        clear()
+        clearUser()
         if (!isMobile) {
             alert({
                 title: '로그아웃 됐어. 다시 돌아올거지?',
@@ -38,9 +39,9 @@ const MainLayout = ({children, logined, isMobile, isGoogleLogin, clear}: PropsWi
         <>
             <MainHeader openSidebar={openSidebar} />
             {children}
-            <MainSidebar isShow={sidebarShow} closeFn={closeSidebar} logined={logined} logout={logoutPage} />
+            <MainSidebar isShow={sidebarShow} closeFn={closeSidebar} logined={isLogined} logout={logoutPage} />
         </>
     )
 }
 
-export default MainLayout
+export default observer(MainLayout)

--- a/src/components/main/MainSidebar.tsx
+++ b/src/components/main/MainSidebar.tsx
@@ -1,0 +1,76 @@
+import SidebarButtonList from '$components/main/SidebarButtonList'
+import Sidebar from '$components/sidebar'
+import ROUTES from '$constants/routes'
+import styled from '@emotion/styled'
+import WelcomeArea from '$components/main/WelcomeArea'
+import {SidebarButton} from '$components/main/types'
+import {useProfileContext} from '$contexts/ProfileContext'
+import LoginedWelcomeArea from '$components/main/LoginedWelcomeArea'
+
+const SidebarContainer = styled.div`
+    padding: 3.2rem 0;
+`
+
+type MainSidebarProps = {
+    isShow: boolean
+    logined: boolean
+    closeFn: () => void
+    logout: () => void
+}
+
+const MainSidebar = ({isShow, logined, closeFn, logout}: MainSidebarProps) => {
+    const {profile} = useProfileContext()
+    const logoutValue: SidebarButton[] = logined
+        ? [
+              {
+                  title: (
+                      <>
+                          <span style={{marginRight: '1.7rem'}}>🏃</span>로그아웃
+                      </>
+                  ),
+                  onClick: () => {
+                      closeFn()
+                      logout()
+                  },
+              },
+          ]
+        : []
+    return (
+        <Sidebar isShow={isShow} closeFn={closeFn}>
+            <SidebarContainer>
+                {logined && profile ? <LoginedWelcomeArea email={profile.email as string} /> : <WelcomeArea />}
+                <SidebarButtonList
+                    list={[
+                        {
+                            title: (
+                                <>
+                                    <span style={{marginRight: '1.7rem'}}>👋</span>안녕, 나야 소개
+                                </>
+                            ),
+                            link: ROUTES.COVID.SIDE.ABOUT,
+                        },
+                        {
+                            title: (
+                                <>
+                                    <span style={{marginRight: '1.7rem'}}>💬</span>자주 묻는 질문
+                                </>
+                            ),
+                            link: '#', // 외부링크
+                        },
+                        {
+                            title: (
+                                <>
+                                    <span style={{marginRight: '1.7rem'}}>💡</span>서비스 피드백
+                                </>
+                            ),
+                            link: '#', // 외부링크
+                        },
+                        ...logoutValue,
+                    ]}
+                />
+            </SidebarContainer>
+        </Sidebar>
+    )
+}
+
+export default MainSidebar

--- a/src/contexts/StoreContext.tsx
+++ b/src/contexts/StoreContext.tsx
@@ -1,11 +1,13 @@
 import {useLocalObservable} from 'mobx-react-lite'
 import {createContext, ReactNode, useContext} from 'react'
 import {AlertState, createAlert} from 'stores/Alert'
+import {AuthStoreState, createAuthStore} from 'stores/Auth'
 import {createLetter, LetterState} from '../stores/Letter'
 
 interface StoreContextState {
     alertStore: AlertState
     letterStore: LetterState
+    authStore: AuthStoreState
 }
 
 const StoreContext = createContext({} as StoreContextState)
@@ -16,6 +18,7 @@ export const StoreProvider = ({children}: {children: ReactNode}) => {
             value={{
                 alertStore: useLocalObservable(createAlert),
                 letterStore: useLocalObservable(createLetter),
+                authStore: useLocalObservable(createAuthStore),
             }}>
             {children}
         </StoreContext.Provider>
@@ -24,3 +27,4 @@ export const StoreProvider = ({children}: {children: ReactNode}) => {
 
 export const useAlertStore = () => useContext(StoreContext).alertStore
 export const useLetterStore = () => useContext(StoreContext).letterStore
+export const useAuthStore = () => useContext(StoreContext).authStore

--- a/src/pages/covid/index.tsx
+++ b/src/pages/covid/index.tsx
@@ -1,4 +1,3 @@
-import {useState} from 'react'
 import {CovidStats, LetterStats} from '$types/response/stat'
 import {numberFormat} from '$utils/index'
 import {withAxios} from '$utils/fetcher/withAxios'
@@ -10,7 +9,7 @@ import AnalyzeSection from '$components/main/AnalyzeSection'
 import {PropsFromApp} from '$types/index'
 import MyLetterSection from '$components/main/MyLetterSection'
 import StatBadge from '$components/main/StatBadge'
-import {useAlertStore} from '$contexts/StoreContext'
+import {useAlertStore, useAuthStore} from '$contexts/StoreContext'
 import {observer} from 'mobx-react-lite'
 import {useRouter} from 'next/router'
 import ROUTES from '$constants/routes'
@@ -20,6 +19,7 @@ import {MainButton} from '$styles/utils/components'
 import useNumberAnimation from '$hooks/useNumberAnimation'
 import {animated} from 'react-spring'
 import MainLayout from '$components/layout/MainLayout'
+import {useEffect} from 'react'
 
 const Container = styled.div`
     ${tw`tw-bg-beige-300`}
@@ -83,7 +83,15 @@ const Main = ({
     isGoogleLogin,
     isMobile,
 }: PropsFromApp<InferGetServerSidePropsType<typeof getServerSideProps>>) => {
-    const [isLogined, setIsLogined] = useState(!!token)
+    const {isLogined, loginUser, clearUser} = useAuthStore()
+
+    useEffect(() => {
+        if (token) {
+            loginUser()
+        } else {
+            clearUser()
+        }
+    }, [token])
 
     const {confirm} = useAlertStore()
     const router = useRouter()
@@ -107,11 +115,7 @@ const Main = ({
     const transitions = useNumberAnimation(numberFormat(unsented + sented))
 
     return (
-        <MainLayout
-            logined={isLogined}
-            isMobile={isMobile}
-            isGoogleLogin={isGoogleLogin}
-            clear={() => setIsLogined(false)}>
+        <MainLayout isMobile={isMobile} isGoogleLogin={isGoogleLogin}>
             <Container>
                 <TitleContainer>
                     <Title>

--- a/src/pages/covid/index.tsx
+++ b/src/pages/covid/index.tsx
@@ -10,12 +10,10 @@ import AnalyzeSection from '$components/main/AnalyzeSection'
 import {PropsFromApp} from '$types/index'
 import MyLetterSection from '$components/main/MyLetterSection'
 import StatBadge from '$components/main/StatBadge'
-import useLogout from '$hooks/useLogout'
 import {useAlertStore} from '$contexts/StoreContext'
 import {observer} from 'mobx-react-lite'
 import {useRouter} from 'next/router'
 import ROUTES from '$constants/routes'
-import toast from '$components/toast'
 import {FontOhsquare, FontOhsquareAir} from '$styles/utils/font'
 import {FlexStart} from '$styles/utils/layout'
 import {MainButton} from '$styles/utils/components'
@@ -87,21 +85,8 @@ const Main = ({
 }: PropsFromApp<InferGetServerSidePropsType<typeof getServerSideProps>>) => {
     const [isLogined, setIsLogined] = useState(!!token)
 
-    const logout = useLogout(isGoogleLogin)
-    const {confirm, alert} = useAlertStore()
+    const {confirm} = useAlertStore()
     const router = useRouter()
-
-    const logoutPage = () => {
-        logout()
-        setIsLogined(false)
-        if (!isMobile) {
-            alert({
-                title: '로그아웃 됐어. 다시 돌아올거지?',
-            })
-        } else {
-            toast('로그아웃 됐어. 다시 돌아올거지?', 1500)
-        }
-    }
 
     const createNewLetter = () => {
         if (!isLogined) {
@@ -122,7 +107,11 @@ const Main = ({
     const transitions = useNumberAnimation(numberFormat(unsented + sented))
 
     return (
-        <MainLayout logined={isLogined} logout={logoutPage}>
+        <MainLayout
+            logined={isLogined}
+            isMobile={isMobile}
+            isGoogleLogin={isGoogleLogin}
+            clear={() => setIsLogined(false)}>
             <Container>
                 <TitleContainer>
                     <Title>

--- a/src/pages/covid/index.tsx
+++ b/src/pages/covid/index.tsx
@@ -1,5 +1,4 @@
 import {useState} from 'react'
-import MainHeader from '$components/header/MainHeader'
 import {CovidStats, LetterStats} from '$types/response/stat'
 import {numberFormat} from '$utils/index'
 import {withAxios} from '$utils/fetcher/withAxios'
@@ -22,6 +21,7 @@ import {FlexStart} from '$styles/utils/layout'
 import {MainButton} from '$styles/utils/components'
 import useNumberAnimation from '$hooks/useNumberAnimation'
 import {animated} from 'react-spring'
+import MainLayout from '$components/layout/MainLayout'
 
 const Container = styled.div`
     ${tw`tw-bg-beige-300`}
@@ -122,8 +122,7 @@ const Main = ({
     const transitions = useNumberAnimation(numberFormat(unsented + sented))
 
     return (
-        <>
-            <MainHeader logined={isLogined} logout={logoutPage} />
+        <MainLayout logined={isLogined} logout={logoutPage}>
             <Container>
                 <TitleContainer>
                     <Title>
@@ -207,7 +206,7 @@ const Main = ({
                 />
                 <MyLetterSection logined={isLogined} />
             </Container>
-        </>
+        </MainLayout>
     )
 }
 

--- a/src/stores/Auth.ts
+++ b/src/stores/Auth.ts
@@ -1,0 +1,19 @@
+export type AuthStoreState = {
+    isLogined: boolean
+    loginUser: () => void
+    clearUser: () => void
+}
+
+const createAuthStore = (): AuthStoreState => {
+    return {
+        isLogined: false,
+        loginUser() {
+            this.isLogined = true
+        },
+        clearUser() {
+            this.isLogined = false
+        },
+    }
+}
+
+export {createAuthStore}


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#

### 작업 분류

-   [ ] 버그 수정
-   [ ] 신규 기능
-   [x] 프로젝트 구조 변경

### 작업 상세 내용

메인헤더와 사이드바를 가진 레이아웃 컴포넌트를 정의합니다.

#### Usage
```js
const MyPage = ({isMobile, isGoogleLogin}: PropsFromApp<unknown>) => {
  return (
    <MainLayout isMobile={isMobile} isGoogleLogin={isGoogleLogin}>
      {...}
    </MainLayout>
  )
}
```
