### PR TITLE
편지 내용 상세 마크업 적용

### DIFF
--- a/src/components/appbar/Back.tsx
+++ b/src/components/appbar/Back.tsx
@@ -1,17 +1,26 @@
 import styled from '@emotion/styled'
 import IconBack from 'assets/icons/IconBack'
 import {useRouter} from 'next/router'
+import tw from 'twin.macro'
 
-const BackContainer = styled.div`
-    position: absolute;
+type ContainerProps = {
+    backgroundColor: string
+}
+
+const Container = styled.div`
+    ${tw`tw-absolute`}
     left: 0%;
     right: 0%;
     height: 5.6rem;
-    background: #eae6d7;
     padding: 1.6rem;
+    background-color: ${({backgroundColor}: ContainerProps) => backgroundColor};
 `
 
-const Back = () => {
+type BackProps = {
+    backgroundColor?: string
+}
+
+const Back = ({backgroundColor = 'var(--beige-300)'}: BackProps) => {
     const router = useRouter()
 
     const handleBack = () => {
@@ -19,11 +28,11 @@ const Back = () => {
     }
 
     return (
-        <BackContainer>
+        <Container backgroundColor={backgroundColor}>
             <button onClick={handleBack}>
                 <IconBack width={'2.4rem'} height={'2.4rem'} />
             </button>
-        </BackContainer>
+        </Container>
     )
 }
 

--- a/src/components/letter/Divider.tsx
+++ b/src/components/letter/Divider.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled'
 import tw from 'twin.macro'
 
 const Divider = styled.div`
-    margin-bottom: 1.6rem; 
     ${tw`tw-border-t-2 tw-border-beige-400 tw-border-dashed`}
 `
 

--- a/src/pages/api/letters/[encryptedId].ts
+++ b/src/pages/api/letters/[encryptedId].ts
@@ -9,12 +9,26 @@ export default async function handler(
     req: NextApiRequest,
     res: NextApiResponse<Response<Letter | null>>
 ) {
-    const {encryptedId} = req.query
+    // const {encryptedId} = req.query
     try {
-        const {data: {errorCode, message, data: letter}}: AxiosResponse<ServerResponse<Letter>> = await axios.get(`${API_URL_BASE}/letters/${encryptedId}`)
-        if (errorCode) {
-            console.info(`errorCode: ${errorCode}, message: ${message}`)
-            throw new Error(message)
+        // const {data: {errorCode, message, data: letter}}: AxiosResponse<ServerResponse<Letter>> = await axios.get(`${API_URL_BASE}/letters/${encryptedId}`)
+        // if (errorCode) {
+        //     console.info(`errorCode: ${errorCode}, message: ${message}`)
+        //     throw new Error(message)
+        // }
+
+        const letter = {
+            title: 'TITLE1',
+            contents: '내용요용용용',
+            email: 'email',
+            name: null,
+            state: 'PENDING',
+            sticker: 'BLUE',
+            questionId: 8,
+            questionText: '질문질문 질문텍스트',
+            encryptedId: 'ENCRYPTED2',
+            sendOptionText: '해외 여행이 가능할 때',
+            createdDate: '2021-08-04T12:09:59'
         }
 
         res.status(200).json({

--- a/src/pages/covid/letter/[encryptedId].tsx
+++ b/src/pages/covid/letter/[encryptedId].tsx
@@ -7,6 +7,11 @@ import ROUTES from '$constants/routes'
 import {useProfileContext} from '$contexts/ProfileContext'
 import HalfLayer from '$components/layer/HalfLayer'
 import {useState} from 'react'
+import Back from '$components/appbar/Back'
+import styled from '@emotion/styled'
+import tw from 'twin.macro'
+import Divider from '$components/letter/Divider'
+import {css} from '@emotion/react'
 
 const ServicePromotion = () => {
     const router = useRouter()
@@ -47,12 +52,30 @@ const LetterDetail = ({letter}: {letter: Letter}) => {
 
     return (
         <>
-            <div>질문: {questionText}</div>
-            <div>작성날짜 | {convertCommonDateFormat(createdDate)}</div>
-            <div>제목: {title}</div>
-            <div>~~~~~~</div>
-            <div>내용: {contents}</div>
-            <button onClick={finishReadLetter}>다 읽었어요!</button>
+            <Back backgroundColor={'var(--beige-200)'}/>
+            <Container>
+                <TitleWrap>
+                    <span className="title-text">{title}</span>
+                    <div className="send-date">
+                        <span>작성날짜</span>
+                        <span className="vertical-divider"></span>
+                        <span>{convertCommonDateFormat(createdDate)}</span>
+                    </div>
+                </TitleWrap>
+
+                <Divider css={dividerCss}/>
+                <ContentsWrap>
+                    <div>{contents}</div>
+                </ContentsWrap>
+                <Divider css={dividerCss}/>
+
+                <QuestionWrap>
+                    <div><span className="description">당시 받았던 질문</span></div>
+                    <div><span className="question-text">{questionText}</span></div>
+                </QuestionWrap>
+            </Container>
+            <ConfirmButton onClick={finishReadLetter}>다 읽었어요!</ConfirmButton>
+
             <HalfLayer isShow={isShowServicePromotion} closeFn={() => setIsShowServicePromotion(false)}>
                 <ServicePromotion />
             </HalfLayer>
@@ -78,5 +101,69 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
         }
     }
 }
+
+const Container = styled.div`
+    ${tw`tw-bg-beige-200`}
+    min-height: 100vh;
+    padding: 5.6rem 0 5.2rem 0;
+`
+
+const TitleWrap = styled.section`
+    padding: 2.4rem;
+    
+    .title-text {
+        ${tw`tw-text-lg`}
+        letter-spacing: -0.015em;
+    }
+    
+    .send-date {
+        ${tw`tw-text-grey-600 tw-font-light tw-text-sm`}
+        letter-spacing: -0.015em;
+        
+        .vertical-divider {
+            ${tw`tw-hue-rotate-90 tw-border-grey-600`}
+            margin: 0 1.2rem;
+            border: 1px solid;
+        }
+    }
+`
+
+const ContentsWrap = styled.section`
+    ${tw`tw-bg-beige-300 tw-text-sm tw-font-light tw-text-grey-800`}
+    min-height: 35.6rem;
+    padding: 2.4rem;
+    letter-spacing: -0.015em;
+`
+
+const QuestionWrap = styled.section`
+    padding: 2.4rem 3.2rem;
+    .description {
+        ${tw`tw-font-light tw-text-xs tw-text-grey-600`}
+        letter-spacing: -0.015em;
+    }
+    
+    .question-text {
+        ${tw`tw-text-sm tw-text-grey-700`}
+        letter-spacing: -0.015em;
+    }
+    
+    div + div {
+        margin-top: 0.8rem;
+    }
+`
+
+const ConfirmButton = styled.button`
+    ${tw`tw-fixed tw-bg-primary-green-500 tw-bottom-0 tw-text-grey-000 tw-font-bold`}
+    max-width: 42rem;
+    width: 100%;
+    height: 5.2rem;
+    font-size: 1.6rem;
+    line-height: 2.5rem;
+`
+
+const dividerCss = css`
+    margin: 0 2.4rem;
+`
+
 
 export default LetterDetail

--- a/src/pages/covid/letter/index.tsx
+++ b/src/pages/covid/letter/index.tsx
@@ -114,11 +114,11 @@ const SubTitle = styled.div`
 `
 
 const ListContainer = styled.div`
-    margin-top: 3.2rem;
+    padding: 0.8rem 0;
 `
 const ItemContainer = styled.div`
     cursor: pointer;    
-    padding-bottom: 1.6rem;
+    margin: 1.6rem 0;
 `
 
 const ItemTitleWrapper = styled.div`


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#64

### 작업 분류

-   [ ] 버그 수정
-   [ ] 신규 기능
-   [ ] 프로젝트 구조 변경
-   [X] 마크업

### 작업 상세 내용
![image](https://user-images.githubusercontent.com/25454596/130343924-b600531f-0847-45ad-8153-5cb03deda5cb.png)

- 편지 내용 상세화면 마크업 적용
- 작업 당시 단건 상세조회 BE API 호출시 에러가있어 우선 mock으로 처리했는데 머지할때는 해당 커밋 제거하겠습니다.
