### PR TITLE
[편지쓰기] 튜토리얼 레이어 추가

### DIFF
--- a/src/assets/icons/IconCurvedArrow.tsx
+++ b/src/assets/icons/IconCurvedArrow.tsx
@@ -1,0 +1,28 @@
+function IconCurvedArrow({style}: {style: React.CSSProperties}) {
+    return (
+        <svg
+            width="1.6rem"
+            height="1.6em"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{display: 'inline-block', ...style}}>
+            <path
+                d="M11.467 1.027S4.857.396 6.285 5.249c1.07 3.197 4.7.563 2.443-.85-1.85-1.157-3.542.71-4.127 1.692-.585.983-2.169 5.519 4.338 7.911"
+                stroke="#F6F4E8"
+                strokeWidth={1.5}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+            <path
+                d="M7.595 15l1.914-.926-1.133-1.83"
+                stroke="#F6F4E8"
+                strokeWidth={1.5}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    )
+}
+
+export default IconCurvedArrow

--- a/src/assets/icons/IconEraser.tsx
+++ b/src/assets/icons/IconEraser.tsx
@@ -1,0 +1,23 @@
+function IconEraser() {
+    return (
+        <svg
+            width="1.6em"
+            height="1.6em"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            style={{
+                display: 'inline-block',
+                marginRight: '.8rem',
+            }}>
+            <path
+                d="M7.648 13H6.282c-.196 0-.391-.04-.572-.12a1.467 1.467 0 01-.483-.347l-1.79-1.895a1.581 1.581 0 01-.323-.51 1.653 1.653 0 010-1.208c.075-.19.185-.365.324-.51l6.876-7.32a.296.296 0 01.211-.09c.08 0 .155.033.212.09l4.175 4.421a.32.32 0 01.088.224.333.333 0 01-.088.224l-6.208 6.574a1.467 1.467 0 01-.483.347c-.182.08-.377.12-.573.12z"
+                stroke="#E7BF78"
+                strokeMiterlimit={10}
+            />
+            <path stroke="#E7BF78" strokeLinecap="round" d="M1.5 13.5h13" />
+        </svg>
+    )
+}
+
+export default IconEraser

--- a/src/components/overlay/index.tsx
+++ b/src/components/overlay/index.tsx
@@ -13,6 +13,9 @@ const Content = styled(animated.div)`
     top: 0;
     background-color: #000;
     opacity: 0;
+    max-width: 420px;
+    width: 100%;
+    margin: 0 auto;
 `
 
 interface OverlayProps {

--- a/src/components/tutorial/SkeletonLayer.tsx
+++ b/src/components/tutorial/SkeletonLayer.tsx
@@ -1,0 +1,342 @@
+import IconCurvedArrow from '$assets/icons/IconCurvedArrow'
+import IconEraser from '$assets/icons/IconEraser'
+import {FontNanumBarunGothic} from '$styles/utils/font'
+import {FlexBetween} from '$styles/utils/layout'
+import styled from '@emotion/styled'
+import {CSSProperties, ReactNode, useRef} from 'react'
+import tw from 'twin.macro'
+
+const Container = styled.section`
+    ${tw`tw-bg-beige-300 tw-flex tw-flex-col`}
+    margin: 0 auto;
+    text-align: center;
+    min-height: calc(100vh - 5.5rem);
+    justify-content: space-between;
+    background-color: rgba(0, 0, 0, 0.5);
+`
+
+const Header = styled.section`
+    height: 5.5rem;
+    background-color: rgba(0, 0, 0, 0.5);
+`
+
+const QuestionContainer = styled.section`
+    ${tw`tw-flex-col tw-justify-between tw-items-center `}
+    min-width: 100%;
+    position: relative;
+`
+const QuestionWrapper = styled.div`
+    margin: 1.6rem 1.4rem 2.4rem;
+    position: relative;
+
+    .question-number {
+        ${FontNanumBarunGothic()}
+        ${tw`tw-text-primary-yellow-400 tw-text-sm`}
+    }
+
+    h3 {
+        ${tw`tw-font-ohsquare-air tw-text-primary-green-500`}
+        margin-top: 1.7rem;
+        margin-bottom: 1.2rem;
+        font-size: 2rem;
+        line-height: 3.2rem;
+        color: transparent;
+    }
+
+    .create-date {
+        ${tw`tw-font-nanumBarunGothic tw-text-grey-600 tw-text-sm`}
+        color: transparent;
+    }
+`
+
+const ButtonList = styled.div`
+    div {
+        ${tw`tw-text-center`}
+    }
+
+    & > div + div {
+        margin-top: 1.2rem;
+    }
+`
+
+const Button = styled.button`
+    ${FontNanumBarunGothic()}
+    ${tw`tw-border tw-border-primary-yellow-400
+        tw-text-primary-yellow-400
+        tw-text-sm
+    `}
+    min-width: 16.2rem;
+    margin: 0 auto;
+    padding: 1rem 1.6rem;
+    height: 4.2rem;
+    box-sizing: border-box;
+    border-radius: 0.4rem;
+`
+
+const LinkButton = styled.a`
+    ${FontNanumBarunGothic()}
+    ${tw`tw-text-primary-yellow-400 tw-text-sm tw-border-0`}
+    padding-bottom: 0.3rem;
+    text-decoration: underline;
+    text-underline-position: under;
+    width: fit-content;
+`
+
+const AnswerWrapper = styled.section`
+    ${tw`tw-flex tw-flex-col`}
+    bottom: 5.2rem;
+    padding: 3.2rem 2.4rem 1.6rem;
+    margin-top: 5.5rem;
+    letter-spacing: -0.015em;
+    border-radius: 1rem;
+    min-height: 40vh;
+    .divider {
+        ${tw`tw-border-t-2 tw-border-dashed`}
+        margin-top: 0.8rem;
+        margin-bottom: 2.4rem;
+        border-color: transparent;
+    }
+`
+
+const TitleInputWrapper = styled.div`
+    ${FlexBetween}
+    min-width: 19.5rem;
+    font-size: 1.8rem;
+    height: 4.2rem;
+
+    input {
+        visibility: hidden;
+    }
+
+    .title {
+        line-height: 2.5rem;
+    }
+    .title-length {
+        font-size: 1.2rem;
+        line-height: 1.4rem;
+    }
+`
+
+const AnswerInputWrapper = styled.div`
+    ${FontNanumBarunGothic()}
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    justify-content: space-between;
+    font-size: 1.4rem;
+    line-height: 2.2rem;
+    min-height: 100%;
+    .answer {
+        width: 100%;
+    }
+    .sub-items {
+        ${tw`tw-text-sm`}
+        display: inherit;
+        justify-content: space-between;
+        margin-top: 2.4rem;
+        .answer-length {
+        }
+        .reset-button {
+            ${tw`tw-text-primary-yellow-400`}
+        }
+    }
+`
+
+const TextAreaWrapper = styled.div`
+    display: inherit;
+    flex-grow: 1;
+    min-height: 8.5rem;
+    .textarea {
+        width: 100%;
+        resize: none !important;
+        visibility: hidden;
+    }
+`
+
+const ConfirmButton = styled.button`
+    ${tw`tw-relative tw-bottom-0`}
+    max-width: 42rem;
+    width: 100%;
+    height: 5.2rem;
+    font-size: 1.6rem;
+    line-height: 2.5rem;
+`
+
+const TutorialWrapper = styled.div`
+    ${FontNanumBarunGothic()}
+    ${tw`tw-text-beige-200 tw-text-sm`}
+    position: absolute;
+    left: 0;
+    right: 0;
+    ${({style}) => {
+        return {
+            ...style,
+        }
+    }}
+
+    .text {
+        margin-bottom: 0.4rem;
+    }
+    .text-bottom {
+        margin-top: 0.4rem;
+    }
+`
+
+const DIRECTION = {
+    UP: 'UP',
+    DOWN: 'DOWN',
+} as const
+type Direction = typeof DIRECTION[keyof typeof DIRECTION]
+
+const TutorialMessage = ({
+    text,
+    direction,
+    target,
+    style,
+    textBottom = false,
+    spacing = 1.6,
+}: {
+    text: string | ReactNode
+    direction: Direction
+    target?: DOMRectList
+    style?: CSSProperties
+    textBottom?: boolean
+    spacing?: number
+}) => {
+    const targetWidth = target ? Array.prototype.slice.call(target)[0].width : 0
+
+    return (
+        <TutorialWrapper style={style}>
+            {!textBottom && <div className="text">{text}</div>}
+            <div
+                className="icon"
+                style={{
+                    marginRight: `${targetWidth / 10 + spacing}rem`,
+                }}>
+                <IconCurvedArrow
+                    style={
+                        direction === DIRECTION.UP
+                            ? {
+                                  transform: `scaleY(-1)`,
+                              }
+                            : {}
+                    }
+                />
+            </div>
+            {textBottom && <div className="text-bottom">{text}</div>}
+        </TutorialWrapper>
+    )
+}
+
+const SkeletonLayer = () => {
+    const tutoRef1 = useRef<HTMLSpanElement>(null)
+    const tutoRef2 = useRef<HTMLButtonElement>(null)
+    const tutoRef3 = useRef<HTMLAnchorElement>(null)
+    const tutoRef4 = useRef<HTMLButtonElement>(null)
+    return (
+        <>
+            <Header />
+            <Container>
+                <QuestionContainer>
+                    <QuestionWrapper>
+                        <TutorialMessage
+                            text="편지쓰기를 도와주는 질문이야!"
+                            direction={DIRECTION.DOWN}
+                            target={tutoRef1.current?.getClientRects()}
+                            style={{
+                                top: '-4rem',
+                            }}
+                        />
+                        <span className="question-number" ref={tutoRef1}>
+                            질문 1
+                        </span>
+                        <h3>
+                            TEST
+                            <br />
+                            TEST
+                        </h3>
+                        <span className="create-date">test</span>
+                    </QuestionWrapper>
+                    <TutorialMessage
+                        text={
+                            <>
+                                현재 질문에 대답하기 어렵다면,
+                                <br />
+                                다른 질문으로 넘어갈 수 있어!
+                            </>
+                        }
+                        direction={DIRECTION.UP}
+                        target={tutoRef2.current?.getClientRects()}
+                        style={{
+                            bottom: '7.2rem',
+                        }}
+                    />
+                    <ButtonList>
+                        <div>
+                            <Button ref={tutoRef2}>다른 질문에 대답할래</Button>
+                        </div>
+                        <div>
+                            <LinkButton ref={tutoRef3}>오늘은 자유롭게 쓸래</LinkButton>
+                        </div>
+                    </ButtonList>
+                    <TutorialMessage
+                        text={
+                            <>
+                                질문을 받지 않고 자유롭게
+                                <br />
+                                편지쓰고 싶을 때 클릭해줘!
+                            </>
+                        }
+                        direction={DIRECTION.DOWN}
+                        target={tutoRef3.current?.getClientRects()}
+                        style={{
+                            bottom: '-7.2rem',
+                        }}
+                        textBottom
+                    />
+                </QuestionContainer>
+                <div>
+                    <AnswerWrapper>
+                        <TitleInputWrapper>
+                            <input />
+                            <span className="title-length"></span>
+                        </TitleInputWrapper>
+                        <hr className="divider" />
+                        <AnswerInputWrapper>
+                            <TextAreaWrapper>
+                                <textarea className="textarea" />
+                            </TextAreaWrapper>
+                            <TutorialMessage
+                                text={
+                                    <>
+                                        내용이 마음에 안든다면?
+                                        <br />
+                                        지우개로 지워봐!
+                                    </>
+                                }
+                                direction={DIRECTION.UP}
+                                target={tutoRef4.current?.getClientRects()}
+                                style={{
+                                    bottom: '1rem',
+                                    textAlign: 'right',
+                                }}
+                                spacing={0}
+                            />
+                            <div className="sub-items">
+                                <span className="answer-length"></span>
+                                <button className="reset-button" ref={tutoRef4}>
+                                    <IconEraser />
+                                    전부 지우기
+                                </button>
+                            </div>
+                        </AnswerInputWrapper>
+                    </AnswerWrapper>
+                    <ConfirmButton></ConfirmButton>
+                </div>
+            </Container>
+        </>
+    )
+}
+
+export default SkeletonLayer

--- a/src/components/tutorial/SkeletonLayer.tsx
+++ b/src/components/tutorial/SkeletonLayer.tsx
@@ -5,7 +5,7 @@ import {HEADER_POSITION, HEADER_TYPE} from '$components/header/constants'
 import {FontNanumBarunGothic} from '$styles/utils/font'
 import {FlexBetween} from '$styles/utils/layout'
 import styled from '@emotion/styled'
-import {CSSProperties, ReactNode, useRef} from 'react'
+import {CSSProperties, ReactNode, useEffect, useRef, useState} from 'react'
 import tw from 'twin.macro'
 
 const Container = styled.section`
@@ -226,11 +226,31 @@ const TutorialMessage = ({
     )
 }
 
+type SkeletonLayerState = {
+    [key: number]: DOMRectList
+}
+
 const SkeletonLayer = () => {
+    const unknownList = [] as unknown as DOMRectList
+    const [, setRectList] = useState<SkeletonLayerState>({
+        1: unknownList,
+        2: unknownList,
+        3: unknownList,
+        4: unknownList,
+    })
     const tutoRef1 = useRef<HTMLSpanElement>(null)
     const tutoRef2 = useRef<HTMLButtonElement>(null)
     const tutoRef3 = useRef<HTMLAnchorElement>(null)
     const tutoRef4 = useRef<HTMLButtonElement>(null)
+
+    useEffect(() => {
+        setRectList({
+            1: tutoRef1.current?.getClientRects() || unknownList,
+            2: tutoRef2.current?.getClientRects() || unknownList,
+            3: tutoRef3.current?.getClientRects() || unknownList,
+            4: tutoRef4.current?.getClientRects() || unknownList,
+        })
+    }, [])
     return (
         <>
             <CommonHeader

--- a/src/components/tutorial/TutorialLayer.tsx
+++ b/src/components/tutorial/TutorialLayer.tsx
@@ -1,0 +1,30 @@
+import usePortal from '$hooks/usePortal'
+import styled from '@emotion/styled'
+import SkeletonLayer from './SkeletonLayer'
+
+const Container = styled.div`
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 2010;
+    width: 100%;
+    max-width: 420px;
+    margin: 0 auto;
+`
+
+const TutorialLayer = ({tutorialShow, closeTutorial}: {tutorialShow: boolean; closeTutorial: () => void}) => {
+    const {Portal} = usePortal()
+
+    if (!tutorialShow) return null
+    return (
+        <Portal>
+            <Container onClick={closeTutorial}>
+                <SkeletonLayer />
+            </Container>
+        </Portal>
+    )
+}
+
+export default TutorialLayer

--- a/src/hooks/useTutorial.ts
+++ b/src/hooks/useTutorial.ts
@@ -1,0 +1,18 @@
+import {useEffect, useState} from 'react'
+
+const useTutorial = (shouldTutorialOpen: boolean) => {
+    const [tutorialShow, toggle] = useState(false)
+    useEffect(() => {
+        if (shouldTutorialOpen) {
+            toggle(true)
+        }
+    }, [shouldTutorialOpen])
+
+    const closeTutorial = () => {
+        toggle(false)
+    }
+
+    return {tutorialShow, closeTutorial}
+}
+
+export default useTutorial

--- a/src/hooks/useTutorial.ts
+++ b/src/hooks/useTutorial.ts
@@ -1,13 +1,8 @@
-import {NEXT_PUBLIC_ENV} from '$config/index'
 import {useEffect, useState} from 'react'
 
 const useTutorial = (shouldTutorialOpen: boolean) => {
     const [tutorialShow, toggle] = useState(false)
     useEffect(() => {
-        if (NEXT_PUBLIC_ENV === 'local') {
-            toggle(true)
-            return
-        }
         if (shouldTutorialOpen) {
             toggle(true)
         }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -147,7 +147,7 @@ class Page extends App<AppProps> {
                             <Device>
                                 {({isMobileOnly: isMobile}) => {
                                     return (
-                                        <Article className="tw-bg-beige-200">
+                                        <Article className="tw-bg-beige-100">
                                             <Container className="tw-bg-beige-300">
                                                 <Component isMobile={isMobile} {...pageProps} />
                                             </Container>

--- a/src/styles/utils/layout.ts
+++ b/src/styles/utils/layout.ts
@@ -12,4 +12,8 @@ const FlexBetween = tw`
     tw-flex tw-flex-1 tw-justify-between tw-items-center
 `
 
-export {FlexCenter, FlexStart, FlexBetween}
+const FlexEnd = tw`
+    tw-flex tw-flex-1 tw-justify-end tw-items-center
+`
+
+export {FlexCenter, FlexStart, FlexBetween, FlexEnd}


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#

### 작업 분류

-   [ ] 버그 수정
-   [x] 신규 기능
-   [ ] 프로젝트 구조 변경

### 작업 상세 내용

튜토리얼 레이어를 추가합니다. 반응형을 고려하여 작성하여 figma 레이아웃과 조금 다른 면이 있습니다.

#### MOBILE
<img width="320" alt="스크린샷 2021-08-24 오후 11 54 17" src="https://user-images.githubusercontent.com/54320809/130640107-94b1702b-0315-4095-8aca-3aad0a381bf9.png">


#### PC
<img width="750" alt="스크린샷 2021-08-24 오후 11 54 01" src="https://user-images.githubusercontent.com/54320809/130640026-000e0e5d-e67a-4778-81d7-85e340ff179d.png">
