### PR TITLE
부치지못한 편지 목록 구현

### DIFF
--- a/src/components/header/MainHeader.tsx
+++ b/src/components/header/MainHeader.tsx
@@ -49,7 +49,7 @@ const LeftButtonList = () => {
         },
         {
             text: '부치지 못한 편지',
-            link: ROUTES.COVID.LETTER.LIST, // 인혁님 브랜치에서 수정 부탁드려요 :)
+            link: ROUTES.COVID.LETTER.UNPOSTED,
         },
     ]
     const router = useRouter()

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -12,6 +12,7 @@ const ROUTES = Object.freeze({
         LETTER: {
             LIST: `${THEME_COVID_PATH}/letter`, // 메인에서 편지목록 더보기 눌렀을때 넘어오는 페이지
             DIRECT: `${THEME_COVID_PATH}/letter/direct`, //메일수신함에서 로그인없이 다이렉트로 접근 시 편지 봉투 모달만 존재
+            UNPOSTED: `${THEME_COVID_PATH}/letter/unposted`, //부치지 못한 편지 목록
             DETAIL: `${THEME_COVID_PATH}/letter/[encryptedId]`, //편지내용 상세 페이지
             OPTION: `${THEME_COVID_PATH}/letter/option`, //편지 작성 시 발송기준 선택 페이지
             NEW: {

--- a/src/pages/covid/letter/index.tsx
+++ b/src/pages/covid/letter/index.tsx
@@ -89,7 +89,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 }
 
 const Container = styled.div`
-    ${tw`tw-bg-beige-300 tw-h-screen`}
+    ${tw`tw-bg-beige-300`}
     min-height: 100vh;
     padding: 3.2rem 2.4rem;
 `

--- a/src/pages/covid/letter/unposted.tsx
+++ b/src/pages/covid/letter/unposted.tsx
@@ -1,0 +1,37 @@
+import MainHeader from '$components/header/MainHeader'
+import {useState} from 'react'
+import useLogout from '$hooks/useLogout'
+import toast from '$components/toast'
+import {PropsFromApp} from '$types/index'
+import {InferGetServerSidePropsType} from 'next'
+import {getServerSideProps} from '../index'
+
+const Unposted = ({
+    token,
+    isGoogleLogin,
+    isMobile,
+}: PropsFromApp<InferGetServerSidePropsType<typeof getServerSideProps>>) => {
+
+    const [isLogined, setIsLogined] = useState(!!token)
+    const logout = useLogout(isGoogleLogin)
+
+    const logoutPage = () => {
+        logout()
+        setIsLogined(false)
+        if (!isMobile) {
+            alert({
+                title: '로그아웃 됐어. 다시 돌아올거지?',
+            })
+        } else {
+            toast('로그아웃 됐어. 다시 돌아올거지?', 1500)
+        }
+    }
+
+    return (
+        <>
+            <MainHeader logined={isLogined} logout={logoutPage} />
+        </>
+    )
+}
+
+export default Unposted


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#69

### 작업 분류

-   [ ] 버그 수정
-   [X] 신규 기능
-   [ ] 프로젝트 구조 변경

### 작업 상세 내용
![image](https://user-images.githubusercontent.com/25454596/130658795-a1f5893a-23f3-44fc-aebe-3e5a0aa2e952.png)

- Empty Case 디자인이 정의되어있지 않아 추후 확인이 필요합니다.
- 현재는 기준 선택 버튼 클릭시 편지id console 출력만 하고 있습니다.
