### PR TITLE
편지 처음 뜯는 경우 편지봉투 모달 노출. 공통 컴포넌트 분리

### DIFF
--- a/src/components/letter/Envelope.tsx
+++ b/src/components/letter/Envelope.tsx
@@ -8,6 +8,8 @@ import {FlexBetween, FlexStart} from '$styles/utils/layout'
 import tw from 'twin.macro'
 import {StickerFactory} from '$components/sticker/stickerFactory'
 import {StampFactory} from '$components/stamp/stampFactory'
+import EnvelopeLoading from '$components/loading/EnvelopeLoading'
+import {useState} from 'react'
 
 type EnvelopeProps = {
     letter: Letter
@@ -20,6 +22,8 @@ const letterOpenButtonText = {
 }
 
 const Envelope = ({letter}: EnvelopeProps) => {
+    const [isShowEnvelopeOpenLoading, setIsShowEnvelopeOpenLoading] = useState<boolean>(false)
+
     const {encryptedId, title, sticker, sendOptionId, sendOptionText, state, createdDate, email, name} = letter
     const isAvailableOpenLetter = state !== LetterState.PENDING
 
@@ -29,6 +33,16 @@ const Envelope = ({letter}: EnvelopeProps) => {
             return
         }
 
+        if (state === LetterState.SEND) {
+            // 처음뜯는 경우 편지로딩 노출
+            setIsShowEnvelopeOpenLoading(true)
+            return
+        }
+
+        goLetterDetail()
+    }
+
+    const goLetterDetail = () => {
         router.push({pathname: ROUTES.COVID.LETTER.DETAIL, query: {encryptedId}})
     }
 
@@ -63,6 +77,7 @@ const Envelope = ({letter}: EnvelopeProps) => {
             <LetterOpenButton disabled={!isAvailableOpenLetter} onClick={openLetter}>
                 {letterOpenButtonText[state]}
             </LetterOpenButton>
+            <EnvelopeLoading isShow={isShowEnvelopeOpenLoading} text={'편지 뜯는 중...'} delay={2000} afterLoadingFn={goLetterDetail}/>
         </Container>
     )
 }

--- a/src/components/loading/EnvelopeLoading.tsx
+++ b/src/components/loading/EnvelopeLoading.tsx
@@ -1,0 +1,68 @@
+import styled from '@emotion/styled'
+import tw from 'twin.macro'
+import LetterEnvelopeImageImage from '$assets/images/LetterEnvelopeImage'
+import {FlexCenter} from '$styles/utils/layout'
+import {FontOhsquareAir} from '$styles/utils/font'
+import {useEffect} from 'react'
+
+const DEFAULT_DELAY = 2000
+
+type EnvelopeLoadingProps = {
+    isShow: boolean
+    text: string
+    delay?: number
+    afterLoadingFn: () => void
+}
+
+const EnvelopeLoading = ({isShow, text, delay = DEFAULT_DELAY, afterLoadingFn}: EnvelopeLoadingProps) => {
+    useEffect(() => {
+        if (isShow) {
+            window.setTimeout(afterLoadingFn, delay)
+        }
+    })
+
+    return (
+        <>
+            {isShow && <Layer>
+                <Container>
+                    <div>
+                        <div className="letter-envelope-image">
+                            <LetterEnvelopeImageImage />
+                        </div>
+                        <LoadingTextWrapper>{text}</LoadingTextWrapper>
+                    </div>
+                </Container>
+            </Layer>}
+        </>
+    )
+}
+
+const Layer = styled.div`
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 2020;
+`
+
+const Container = styled.div`
+    ${FlexCenter}
+    ${tw`tw-bg-beige-300`}
+    max-width: 420px;
+    margin: 0 auto;
+    min-height: 100vh;
+    position: relative;
+    
+    .letter-envelope-image {
+        ${FlexCenter}
+    }
+`
+
+const LoadingTextWrapper = styled.div`
+    ${FontOhsquareAir}
+    ${tw`tw-text-base tw-text-center tw-text-primary-green-400`}
+    letter-spacing: -0.015em;
+    margin-top: 1.6rem;
+`
+
+export default EnvelopeLoading


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#97

### 작업 분류

-   [ ] 버그 수정
-   [X] 신규 기능
-   [ ] 프로젝트 구조 변경

### 작업 상세 내용
![image](https://user-images.githubusercontent.com/25454596/130669359-b32397f0-0603-4934-aa7b-58206929bd1c.png)

- 편지를 처음 뜯는 경우 봉투모달 로딩화면이 보였다가 다음화면으로 넘어가도록 수정
- 봉투모달 로딩화면 컴포넌트 분리
