### PR TITLE
부치지 못한 편지목록 Empty case, 편지내용상세 뒤로가기 버튼 동작

### DIFF
--- a/src/components/letter/EmptyLetterListContainer.tsx
+++ b/src/components/letter/EmptyLetterListContainer.tsx
@@ -16,11 +16,11 @@ const EmptyLetterListContainer = () => {
         <Container>
             <EmptyLetterImage />
             <SubTitle>
-                <span className="text">
+                <div className="text">
                     작성된 편지가 없어.
                     <br />
                     한번 편지를 쓰러 가볼까?
-                </span>
+                </div>
             </SubTitle>
             <CreateLetterButton onClick={createNewLetter}>편지 작성</CreateLetterButton>
         </Container>
@@ -31,27 +31,10 @@ const Container = styled.div`
     ${FlexCenter}
     ${tw`tw-flex-col`}
     margin-top: 7.6rem;
-
-    .btn {
-        margin-top: 3.2rem;
-        ${FlexCenter}
-        ${tw`tw-bg-primary-green-500 tw-w-full`}
-        height: 5.2rem;
-        border-radius: 0.4rem;
-
-        .text {
-            font-family: Cafe24 Ohsquare;
-            font-weight: bold;
-            font-size: 16px;
-            line-height: 25px;
-            ${tw`tw-text-grey-000`}
-        }
-    }
 `
 
 const SubTitle = styled.div`
     margin-top: 1.6rem;
-
     .text {
         ${tw`tw-text-sm tw-text-center tw-text-primary-green-500 tw-font-normal`}
     }

--- a/src/components/letter/EmptyUnpostedLetterListContainer.tsx
+++ b/src/components/letter/EmptyUnpostedLetterListContainer.tsx
@@ -1,0 +1,34 @@
+import styled from '@emotion/styled'
+import {FlexCenter} from '$styles/utils/layout'
+import tw from 'twin.macro'
+import EmptyLetterImage from '$assets/images/EmptyLetterImage'
+
+const EmptyUnpostedLetterListContainer = () => {
+    return (
+        <Container>
+            <EmptyLetterImage />
+            <SubTitle>
+                <div className="text">
+                    아직 부치지 못한 편지가 없어.
+                    <br />
+                    발송 기준을 정하지 못한 편지가 생기면 찾아와줘!
+                </div>
+            </SubTitle>
+        </Container>
+    )
+}
+
+const Container = styled.div`
+    ${FlexCenter}
+    ${tw`tw-flex-col`}
+    margin-top: 7.6rem;
+`
+
+const SubTitle = styled.div`
+    margin-top: 1.6rem;
+    .text {
+        ${tw`tw-text-sm tw-text-center tw-text-primary-green-500 tw-font-normal`}
+    }
+`
+
+export default EmptyUnpostedLetterListContainer

--- a/src/components/main/MainSidebar.tsx
+++ b/src/components/main/MainSidebar.tsx
@@ -6,6 +6,7 @@ import Welcome from '$components/main/Welcome'
 import {SidebarButton} from '$components/main/types'
 import {useProfileContext} from '$contexts/ProfileContext'
 import LoginedWelcomeArea from '$components/main/LoginedWelcomeArea'
+import {EXTERNAL_URL} from '$constants'
 
 const SidebarContainer = styled.div`
     padding: 3.2rem 0;
@@ -55,7 +56,7 @@ const MainSidebar = ({isShow, logined, closeFn, logout}: MainSidebarProps) => {
                                     <span style={{marginRight: '1.7rem'}}>💬</span>자주 묻는 질문
                                 </>
                             ),
-                            link: '#', // 외부 링크
+                            link: EXTERNAL_URL.QNA,
                         },
                         {
                             title: (
@@ -63,7 +64,7 @@ const MainSidebar = ({isShow, logined, closeFn, logout}: MainSidebarProps) => {
                                     <span style={{marginRight: '1.7rem'}}>💡</span>서비스 피드백
                                 </>
                             ),
-                            link: '#', // 외부 링크
+                            link: EXTERNAL_URL.FEEDBACK,
                         },
                         ...logoutValue,
                     ]}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -89,3 +89,8 @@ export const TIME_UNIT = {
 
 export const COMMON_OPTION_ID = 6
 export const NO_OPTION_ID = 7
+
+export const EXTERNAL_URL = {
+    QNA: 'https://bit.ly/2UPQeah',
+    FEEDBACK: 'https://bit.ly/3jjntvT',
+}

--- a/src/pages/covid/letter/[encryptedId].tsx
+++ b/src/pages/covid/letter/[encryptedId].tsx
@@ -38,9 +38,12 @@ const LetterDetail = ({letter}: {letter: Letter}) => {
         setIsShowServicePromotion(true)
     }
     const handleHeader = () => {
-        router.push({
-            pathname: ROUTES.COVID.MAIN,
-        })
+        if (window.history.length < 3) {
+            router.push({pathname: ROUTES.COVID.MAIN})
+            return
+        }
+
+        router.back()
     }
 
     return (

--- a/src/pages/covid/letter/unposted.tsx
+++ b/src/pages/covid/letter/unposted.tsx
@@ -13,6 +13,7 @@ import {StickerWithLetterFactory} from '$components/sticker/stickerWithLetterFac
 import {convertCommonDateFormat} from '$utils/date'
 import {useRouter} from 'next/router'
 import ROUTES from '$constants/routes'
+import EmptyUnpostedLetterListContainer from '$components/letter/EmptyUnpostedLetterListContainer'
 
 const Unposted = ({
     isGoogleLogin,
@@ -27,6 +28,28 @@ const Unposted = ({
         })
     }
 
+    const unpostedLetterList = letters.length === 0
+        ? <EmptyUnpostedLetterListContainer />
+        : <LettersContainer>
+            {letters.map(({title, sticker, createdDate, encryptedId}: Letter, index: number) => (
+                <LetterItemContainer key={encryptedId}>
+                    <LetterItem>
+                        <div className="sticker-title-wrapper">
+                            {StickerWithLetterFactory(sticker)}
+                            <LetterItemTitleWrapper>
+                                <div className="title">{title}</div>
+                                <div className="date">작성일: {convertCommonDateFormat(createdDate)}</div>
+                            </LetterItemTitleWrapper>
+                        </div>
+                        <SelectSendOptionButton onClick={() => goSelectSendOption({encryptedId})}>
+                            기준 선택
+                        </SelectSendOptionButton>
+                    </LetterItem>
+                    {index !== letters.length - 1 && <Divider />}
+                </LetterItemContainer>
+            ))}
+        </LettersContainer>
+
     return (
         <MainLayout isMobile={isMobile} isGoogleLogin={isGoogleLogin}>
             <Container>
@@ -34,25 +57,7 @@ const Unposted = ({
                     부치지 못한 편지<span className="icon-letter">📦️</span>
                 </TitleContainer>
                 <SubTitle>발송 기준을 정하고 편지를 받아봐!</SubTitle>
-                <LettersContainer>
-                    {letters.map(({title, sticker, createdDate, encryptedId}: Letter, index: number) => (
-                        <LetterItemContainer key={encryptedId}>
-                            <LetterItem>
-                                <div className="sticker-title-wrapper">
-                                    {StickerWithLetterFactory(sticker)}
-                                    <LetterItemTitleWrapper>
-                                        <div className="title">{title}</div>
-                                        <div className="date">작성일: {convertCommonDateFormat(createdDate)}</div>
-                                    </LetterItemTitleWrapper>
-                                </div>
-                                <SelectSendOptionButton onClick={() => goSelectSendOption({encryptedId})}>
-                                    기준 선택
-                                </SelectSendOptionButton>
-                            </LetterItem>
-                            {index !== letters.length - 1 && <Divider />}
-                        </LetterItemContainer>
-                    ))}
-                </LettersContainer>
+                {unpostedLetterList}
             </Container>
         </MainLayout>
     )
@@ -97,7 +102,8 @@ const SubTitle = styled.div`
 `
 
 const LettersContainer = styled.div`
-    margin-top: 4.4rem;
+    margin-top: 3.6rem;
+    padding: 0.8rem 0;
 `
 
 const LetterItemContainer = styled.div`


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#69

### 작업 분류

-   [X] 버그 수정
-   [X] 신규 기능
-   [ ] 프로젝트 구조 변경

### 작업 상세 내용

![image](https://user-images.githubusercontent.com/25454596/130997544-7de21415-d9dd-4616-bab2-63c1a0fb88ca.png)

- 부치지 못한 편지목록 화면. 발송기준 선택안한 편지 없는 케이스 마크업 적용
- 편지내용상세 화면 뒤로가기 버튼 동작 처리
```
편지내용상세화면은 두 가지로 방법으로 접근
1. 이메일링크에 있는 최초 진입 화면 (비어있고 편지봉투 모달만 존재)
2. 로그인 이후 편지목록 편지봉투 모달통해 이동
위 두가지의 경우 next/router 제공하는 router.back() 가능

편지 내용상세 화면에서 URL을 복사해서 새창으로 붙여넣으면 바로 편지내용상세로 가게되는데 이때 router.back() 요청하면 새탭으로 가버린다.

원래는 새탭으로 돌아가는 것이 맞지만 최대한 사용자를 잡아두기 위해 새탭에서 주소를 넣어 이동한경우 고려하여 해당 케이스에는 메인화면으로 이동한다.
```

