### PR TITLE
편지봉투 내 구분선 마크업 수정

### DIFF
--- a/src/components/letter/Envelope.tsx
+++ b/src/components/letter/Envelope.tsx
@@ -130,8 +130,9 @@ const DescWrapper = styled.div`
         ${tw`tw-font-light tw-text-grey-600`}
     }
 `
-const Divider = styled.div`
-    ${tw`tw-border-2 tw-border-solid tw-border-grey-200`}
+const Divider = styled.hr`
+    ${tw`tw-border-grey-200`}
+    border-top-width: 0.2rem;
     margin: 3.2rem 0 2.4rem 0;
 `
 


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#151

### 작업 분류

-   [X] 버그 수정
-   [ ] 신규 기능
-   [ ] 프로젝트 구조 변경

### 작업 상세 내용
![image](https://user-images.githubusercontent.com/25454596/131076932-09dd81e4-0c99-40ac-89bf-7f2f0b95d8f9.png)

구분선 굵기가 디자인가이드와 달라 수정하였습니다.
