### PR TITLE
메인 통계 수정, 프로필 정보 조회 오류 시 강제 로그아웃

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -23,9 +23,11 @@ const MainLayout = ({children, isMobile, isGoogleLogin}: PropsWithChildren<MainL
     const logout = useLogout(isGoogleLogin)
     const {alert} = useAlertStore()
 
-    const logoutPage = () => {
+    const logoutPage = (shouldOpenResultAlert = true) => {
         logout()
         clearUser()
+
+        if (!shouldOpenResultAlert) return
         if (!isMobile) {
             alert({
                 title: '로그아웃 됐어. 다시 돌아올거지?',

--- a/src/components/main/MainSidebar.tsx
+++ b/src/components/main/MainSidebar.tsx
@@ -7,6 +7,9 @@ import {SidebarButton} from '$components/main/types'
 import {useProfileContext} from '$contexts/ProfileContext'
 import LoginedWelcomeArea from '$components/main/LoginedWelcomeArea'
 import {EXTERNAL_URL} from '$constants'
+import {useAlertStore} from '$contexts/StoreContext'
+import {useEffect} from 'react'
+import {useRouter} from 'next/router'
 
 const SidebarContainer = styled.div`
     padding: 3.2rem 0;
@@ -16,11 +19,13 @@ type MainSidebarProps = {
     isShow: boolean
     logined: boolean
     closeFn: () => void
-    logout: () => void
+    logout: (shouldOpenResultAlert?: boolean) => void
 }
 
 const MainSidebar = ({isShow, logined, closeFn, logout}: MainSidebarProps) => {
-    const {profile} = useProfileContext()
+    const {profile, error} = useProfileContext()
+    const {alert} = useAlertStore()
+    const router = useRouter()
     const logoutValue: SidebarButton[] = logined
         ? [
               {
@@ -36,6 +41,23 @@ const MainSidebar = ({isShow, logined, closeFn, logout}: MainSidebarProps) => {
               },
           ]
         : []
+
+    useEffect(() => {
+        if (error) {
+            logout(false)
+            alert({
+                title: `로그아웃되었어.\n다시 로그인해줄래?`,
+                successText: '다시 로그인할래',
+                onSuccess: () => {
+                    router.replace(ROUTES.LOGIN)
+                },
+                onClose: () => {
+                    router.replace(ROUTES.LOGIN)
+                },
+            })
+        }
+    }, [error])
+
     return (
         <Sidebar isShow={isShow} closeFn={closeFn}>
             <SidebarContainer>

--- a/src/pages/api/covidstat.ts
+++ b/src/pages/api/covidstat.ts
@@ -4,7 +4,8 @@ import {NextApiRequest, NextApiResponse} from 'next'
 import {CovidStatResponse} from '$types/response/stat'
 import {API_URL_BASE} from '$config/index'
 import axios, {AxiosResponse} from 'axios'
-import {numberFormat} from '$utils/index'
+import {numberFormat, pad1Digits} from '$utils/index'
+import {format} from 'date-fns'
 
 const parseToNumber = ({
     vaccinated,
@@ -14,40 +15,44 @@ const parseToNumber = ({
     cured,
     curedPer,
     ...rest
-}: CovidStatResponse<number>): CovidStatResponse<string> => ({
-    vaccinated: numberFormat(vaccinated),
-    vaccinatedPer: numberFormat(vaccinatedPer),
-    confirmed: numberFormat(confirmed),
-    confirmedPer: numberFormat(confirmedPer),
-    cured: numberFormat(cured),
-    curedPer: numberFormat(curedPer),
-    ...rest,
-})
+}: CovidStatResponse): CovidStatResponse => {
+    const padVaccinated = pad1Digits(+vaccinated)
+    const padVaccinatedPer = pad1Digits(+vaccinatedPer)
+    return {
+        vaccinated: numberFormat(+padVaccinated),
+        vaccinatedPer: numberFormat(+padVaccinatedPer),
+        confirmed: numberFormat(+confirmed),
+        confirmedPer: numberFormat(+confirmedPer),
+        cured: numberFormat(+cured),
+        curedPer: numberFormat(+curedPer),
+        ...rest,
+    }
+}
 
-const routes = async (req: NextApiRequest, res: NextApiResponse<Response<CovidStatResponse<string>>>) => {
+const routes = async (req: NextApiRequest, res: NextApiResponse<Response<CovidStatResponse>>) => {
     try {
         const {
             data: {data},
-        }: AxiosResponse<ServerResponse<CovidStatResponse<number>>> = await axios.get(`${API_URL_BASE}/covidstat`, {
+        }: AxiosResponse<ServerResponse<CovidStatResponse>> = await axios.get(`${API_URL_BASE}/covidstat`, {
             headers: req.headers,
         })
 
         const result = parseToNumber(data)
 
-        res.status(200).json(createResponse<CovidStatResponse<string>>(result))
+        res.status(200).json(createResponse<CovidStatResponse>(result))
         return
     } catch {
         res.status(200).json(
-            createResponse<CovidStatResponse<string>>({
-                date: '2021-08-23',
-                vaccinated: '11,112,222', // 2차 접종 완료자 수   <-- 접종 완료율로 변경 필요!!
-                vaccinatedPer: '22,222', // 2차 접종 완료자 수 (전일대비 증감량) <-- 접종 완료율로 변경 필요!!
-                confirmed: '111,111', // 확진자수
-                confirmedPer: '1,112', // 확진자수 (전일대비 증감량)
-                cured: '222,222', // 완치자수
-                curedPer: '2,222', // 완치자수 (전일대비 증감량)
-                lettersSend: 11, // 발송된 편지
-                lettersPending: 2, // 미발송 편지수
+            createResponse<CovidStatResponse>({
+                date: format(new Date(), 'yyyy-MM-dd'),
+                vaccinated: '0', // 2차 접종 완료율
+                vaccinatedPer: '0', // 2차 접종 완료율 (전일대비 증감량)
+                confirmed: '0', // 확진자수
+                confirmedPer: '0', // 확진자수 (전일대비 증감량)
+                cured: '0', // 완치자수
+                curedPer: '0', // 완치자수 (전일대비 증감량)
+                lettersSend: 0, // 발송된 편지
+                lettersPending: 0, // 미발송 편지수
             }),
         )
     }

--- a/src/pages/api/covidstat.ts
+++ b/src/pages/api/covidstat.ts
@@ -14,8 +14,7 @@ const parseToNumber = ({
     confirmedPer,
     cured,
     curedPer,
-    ...rest
-}: CovidStatResponse): CovidStatResponse => {
+}: CovidStatResponse): Omit<CovidStatResponse, 'date' | 'lettersSend' | 'lettersPending'> => {
     const padVaccinated = pad1Digits(+vaccinated)
     const padVaccinatedPer = pad1Digits(+vaccinatedPer)
     return {
@@ -25,7 +24,6 @@ const parseToNumber = ({
         confirmedPer: numberFormat(+confirmedPer),
         cured: numberFormat(+cured),
         curedPer: numberFormat(+curedPer),
-        ...rest,
     }
 }
 
@@ -37,9 +35,14 @@ const routes = async (req: NextApiRequest, res: NextApiResponse<Response<CovidSt
             headers: req.headers,
         })
 
-        const result = parseToNumber(data)
+        const covidStats = parseToNumber(data)
 
-        res.status(200).json(createResponse<CovidStatResponse>(result))
+        res.status(200).json(
+            createResponse<CovidStatResponse>({
+                ...data,
+                ...covidStats,
+            }),
+        )
         return
     } catch {
         res.status(200).json(

--- a/src/pages/covid/index.tsx
+++ b/src/pages/covid/index.tsx
@@ -3,10 +3,10 @@ import {numberFormat} from '$utils/index'
 import {withAxios} from '$utils/fetcher/withAxios'
 import styled from '@emotion/styled'
 import HomeImage from 'assets/images/HomeImage'
-import {GetServerSidePropsContext, InferGetServerSidePropsType} from 'next'
+import {InferGetServerSidePropsType} from 'next'
 import tw from 'twin.macro'
 import AnalyzeSection from '$components/main/AnalyzeSection'
-import {PropsFromApp, ValueMap} from '$types/index'
+import {PropsFromApp} from '$types/index'
 import MyLetterSection from '$components/main/MyLetterSection'
 import StatBadge from '$components/main/StatBadge'
 import {useAlertStore, useAuthStore} from '$contexts/StoreContext'
@@ -20,8 +20,6 @@ import useNumberAnimation from '$hooks/useNumberAnimation'
 import {animated} from 'react-spring'
 import MainLayout from '$components/layout/MainLayout'
 import {useEffect} from 'react'
-import cookies from 'next-cookies'
-import {getIntervalFromTodayToNextday} from '$utils/date'
 
 const Container = styled.div`
     ${tw`tw-bg-beige-300`}
@@ -194,27 +192,33 @@ const Main = ({
  *
  * @todo 코로나 통계, 편지 통계 가져올 때 활용
  */
-export async function getServerSideProps({req, res}: GetServerSidePropsContext) {
-    const {covidApiResult} = cookies({req})
-    if (covidApiResult) {
-        return {
-            props: Object.assign({}, covidApiResult as unknown as ValueMap) as CovidStatResponse<string>,
-        }
-    }
-    const stats = await withAxios<CovidStatResponse<string>>({
+export async function getServerSideProps() {
+    /**
+     * @deprecated 쿠키에 캐싱된 데이터 리턴하는 로직
+     */
+    // const {covidApiResult} = cookies({req})
+    // if (covidApiResult) {
+    //     return {
+    //         props: Object.assign({}, covidApiResult as unknown as ValueMap) as CovidStatResponse,
+    //     }
+    // }
+
+    const stats = await withAxios<CovidStatResponse>({
         url: '/covidstat',
     })
 
     if (!stats) {
         return {
-            props: {} as CovidStatResponse<string>,
+            props: {} as CovidStatResponse,
             notFound: true,
         }
     }
 
-    const maxAge = getIntervalFromTodayToNextday()
-
-    res?.setHeader('Set-Cookie', `covidApiResult=${JSON.stringify(stats)}; path=/; max-age=${maxAge}`)
+    /**
+     * @deprecated 쿠키에 캐싱하는 로직
+     */
+    // const maxAge = getIntervalFromTodayToNextday()
+    // res?.setHeader('Set-Cookie', `covidApiResult=${JSON.stringify(stats)}; path=/; max-age=${maxAge}`)
 
     return {
         props: {...stats},

--- a/src/pages/covid/index.tsx
+++ b/src/pages/covid/index.tsx
@@ -70,8 +70,8 @@ const AnimatedSpan = styled(animated.span)`
 `
 
 const Main = ({
-    vaccinated, // 2차 접종 완료자 수   <-- 접종 완료율로 변경 필요!!
-    vaccinatedPer, // 2차 접종 완료자 수 (전일대비 증감량) <-- 접종 완료율로 변경 필요!!
+    vaccinated, // 2차 접종 완료율
+    vaccinatedPer, // 2차 접종 완료율 (전일대비 증감량)
     confirmed, // 확진자수
     confirmedPer, // 확진자수 (전일대비 증감량)
     cured, // 완치자수

--- a/src/types/response/stat.ts
+++ b/src/types/response/stat.ts
@@ -1,14 +1,14 @@
-export type CovidStatResponse<T = number | string> = {
+export type CovidStatResponse = {
     date: string
 
-    vaccinated: T // 2차 접종 완료자 수   <-- 접종 완료율로 변경 필요!!
-    vaccinatedPer: T // 2차 접종 완료자 수 (전일대비 증감량) <-- 접종 완료율로 변경 필요!!
+    vaccinated: string // 2차 접종 완료율
+    vaccinatedPer: string // 2차 접종 완료율 (전일대비 증감량)
 
-    confirmed: T // 확진자수
-    confirmedPer: T // 확진자수 (전일대비 증감량)
+    confirmed: string // 확진자수
+    confirmedPer: string // 확진자수 (전일대비 증감량)
 
-    cured: T // 완치자수
-    curedPer: T // 완치자수 (전일대비 증감량)
+    cured: string // 완치자수
+    curedPer: string // 완치자수 (전일대비 증감량)
 
     lettersSend: number // 발송된 편지
     lettersPending: number // 미발송 편지수

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,5 @@ export const numberFormat = (number: number) => {
     const regexp = /\B(?=(\d{3})+(?!\d))/g
     return number.toString().replace(regexp, ',')
 }
+
+export const pad1Digits = (number: number) => number.toFixed(1)


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#150

### 작업 분류

-   [x] 버그 수정
-   [ ] 신규 기능
-   [ ] 프로젝트 구조 변경

### 작업 상세 내용

메인 통계에서 백분율로 받은 접종률을 소수점 1자리로 패딩합니다.
쿠키에 당일 자정까지 캐싱했던 로직을 deprecated합니다. (혹시나 싶어서 지우진 않았습니다 ㅎㅎ;)
프로필 정보에서 오류를 받으면 강제로그아웃합니다.