### PR TITLE
하프레이어 닫히고 난 후에 상태값 해제, 메인 배경 패턴 계산 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,11 @@
     },
     "lint-staged": {
         "**/*.{json,yaml,md}": "prettier --check",
-        "**/*.{js,jsx,tsx}": "eslint"
+        "**/*.{js,jsx,tsx}": [
+            "eslint --fix",
+            "prettier --write",
+            "git add"
+        ]
     },
     "husky": {
         "hooks": {

--- a/src/components/layer/HalfLayer.tsx
+++ b/src/components/layer/HalfLayer.tsx
@@ -24,7 +24,6 @@ const Content = styled(animated.div)`
     right: 0;
     bottom: 0;
     z-index: 10;
-    background-color: ${({bgColor}: {bgColor: string}) => bgColor};
     box-sizing: border-box;
     text-align: center;
     border-top-left-radius: 1rem;
@@ -71,9 +70,7 @@ const HalfLayer = ({
                 return (
                     item && (
                         <Container>
-                            <Content style={props} bgColor={bgColor}>
-                                {children}
-                            </Content>
+                            <Content style={{...props, backgroundColor: bgColor}}>{children}</Content>
                             <Overlay shouldScrollLock isShow={isShowOverlay} position={'fixed'} closeFn={closeFn} />
                         </Container>
                     )

--- a/src/components/layer/HalfLayer.tsx
+++ b/src/components/layer/HalfLayer.tsx
@@ -4,6 +4,7 @@ import bezierEasing from 'bezier-easing'
 import styled from '@emotion/styled'
 import React, {PropsWithChildren} from 'react'
 import Overlay from '$components/overlay'
+import {noop} from '$utils/index'
 
 const Container = styled.div`
     position: fixed;
@@ -36,9 +37,17 @@ interface HalfLayerProps {
     isShowOverlay?: boolean
     bgColor?: string
     closeFn: (e: React.SyntheticEvent) => void
+    onDestroyed?: () => void
 }
 
-const HalfLayer = ({children, isShow, isShowOverlay = true, closeFn, bgColor = '#fff'}: PropsWithChildren<HalfLayerProps>) => {
+const HalfLayer = ({
+    children,
+    isShow,
+    isShowOverlay = true,
+    closeFn,
+    bgColor = '#fff',
+    onDestroyed = noop,
+}: PropsWithChildren<HalfLayerProps>) => {
     const {Portal} = usePortal()
 
     const transitions = useTransition(isShow, {
@@ -49,6 +58,11 @@ const HalfLayer = ({children, isShow, isShowOverlay = true, closeFn, bgColor = '
             duration: 300,
             easing: bezierEasing(0.33, 0, 0.2, 1),
         },
+        onDestroyed: (prevIsShow: boolean) => {
+            if (prevIsShow) {
+                onDestroyed()
+            }
+        },
     })
 
     return (
@@ -57,7 +71,9 @@ const HalfLayer = ({children, isShow, isShowOverlay = true, closeFn, bgColor = '
                 return (
                     item && (
                         <Container>
-                            <Content style={props} bgColor={bgColor}>{children}</Content>
+                            <Content style={props} bgColor={bgColor}>
+                                {children}
+                            </Content>
                             <Overlay shouldScrollLock isShow={isShowOverlay} position={'fixed'} closeFn={closeFn} />
                         </Container>
                     )

--- a/src/components/main/PcBackground.tsx
+++ b/src/components/main/PcBackground.tsx
@@ -101,7 +101,7 @@ const PcBackground = () => {
         const patternHeight = patternColRef.current?.clientHeight
 
         if (patternHeight) {
-            const numOfColPatterns = Math.ceil(document.body.clientHeight / patternHeight)
+            const numOfColPatterns = Math.ceil(window.innerHeight / patternHeight)
             setNumOfNeededPatterns(numOfColPatterns - 1)
         }
     }, [])

--- a/src/pages/covid/about.tsx
+++ b/src/pages/covid/about.tsx
@@ -13,7 +13,7 @@ import tw from 'twin.macro'
 const TitleSection = styled.div`
     ${FlexCenter}
     ${FontOhsquareAir}
-    ${tw`tw-text-2xl tw-text-center`}
+    ${tw`tw-text-2xl tw-text-center tw-text-primary-green-500`}
     margin-top: 3.6rem;
 `
 

--- a/src/pages/covid/about.tsx
+++ b/src/pages/covid/about.tsx
@@ -24,7 +24,7 @@ const ImageSection = styled.div`
 `
 
 const IntroSection = styled.div`
-    background-color: rgba(246, 244, 232, 0.8);
+    ${tw`tw-bg-beige-200`}
     border-radius: 2.4rem 2.4rem 0px 0px;
     padding: 4rem 2.4rem 3.2rem;
 

--- a/src/pages/covid/letter/index.tsx
+++ b/src/pages/covid/letter/index.tsx
@@ -17,55 +17,62 @@ import {LetterStateTagFactory} from '$components/letter/LetterStateTagFactory'
 import Envelope from '$components/letter/Envelope'
 
 const Letters = ({letters}: {letters: Letter[]}) => {
-
     const [isShowEnvelope, setIsShowEnvelop] = useState<boolean>(false)
     const [openedLetter, setOpenedLetter] = useState<Letter | null>(null)
 
     const openEnvelope = (encryptedId: string) => {
-        setOpenedLetter(letters.filter(letter => letter.encryptedId === encryptedId)[0])
+        setOpenedLetter(letters.filter((letter) => letter.encryptedId === encryptedId)[0])
         setIsShowEnvelop(true)
     }
     const closeEnvelope = () => {
-        setOpenedLetter(null)
         setIsShowEnvelop(false)
     }
 
-    const letterList = letters.length === 0
-        ? <EmptyLetterListContainer />
-        : <ListContainer>
+    const onDestroyHalfLayer = () => {
+        setOpenedLetter(null)
+    }
+
+    const letterList =
+        letters.length === 0 ? (
+            <EmptyLetterListContainer />
+        ) : (
+            <ListContainer>
                 {letters.map(({title, state, sticker, createdDate, encryptedId, sendOptionText}, index) => (
                     <div key={encryptedId}>
                         <ItemContainer className="letter_item" onClick={() => openEnvelope(encryptedId)}>
                             <ItemTitleWrapper>
-                                <span className='text'>{title}</span>
+                                <span className="text">{title}</span>
                                 {LetterStateTagFactory(state)}
                             </ItemTitleWrapper>
                             <ItemDescWrapper>
-                                <div className='text-wrap'>
+                                <div className="text-wrap">
                                     작성일: {convertCommonDateFormat(createdDate)}
-                                    <br/>
+                                    <br />
                                     발송기준: {sendOptionText}
                                 </div>
                                 {StickerWithLetterFactory(sticker)}
                             </ItemDescWrapper>
                         </ItemContainer>
-                        {index !== letters.length - 1 && <Divider/>}
+                        {index !== letters.length - 1 && <Divider />}
                     </div>
                 ))}
-          </ListContainer>
+            </ListContainer>
+        )
 
     return (
         <>
             <Back />
             <Container>
                 <LettersContainer>
-                    <TitleContainer>작성한 편지 목록 <span className="icon-letter">✉️</span></TitleContainer>
+                    <TitleContainer>
+                        작성한 편지 목록 <span className="icon-letter">✉️</span>
+                    </TitleContainer>
                     <SubTitle>과거의 내가 작성한 편지들이야.</SubTitle>
                     {letterList}
                 </LettersContainer>
 
-                <HalfLayer isShow={isShowEnvelope} closeFn={closeEnvelope} >
-                    {openedLetter && (<Envelope letter={openedLetter} />)}
+                <HalfLayer isShow={isShowEnvelope} closeFn={closeEnvelope} onDestroyed={onDestroyHalfLayer}>
+                    {openedLetter && <Envelope letter={openedLetter} />}
                 </HalfLayer>
             </Container>
         </>
@@ -116,7 +123,7 @@ const ListContainer = styled.div`
     padding: 0.8rem 0;
 `
 const ItemContainer = styled.div`
-    cursor: pointer;    
+    cursor: pointer;
     margin: 1.6rem 0;
 `
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -37,7 +37,7 @@ const Img = styled.div`
 `
 
 const Intro = styled.div`
-    background-color: rgba(246, 244, 232, 0.8);
+    ${tw`tw-bg-beige-200`}
     border-radius: 2.4rem 2.4rem 0px 0px;
     padding: 4.2rem 2.4rem 3.2rem;
 `


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#154

### 작업 분류

-   [x] 버그 수정
-   [ ] 신규 기능
-   [ ] 프로젝트 구조 변경

### 작업 상세 내용

1. 하프레이어가 close 될 떄 opendLetter를 Null로 만듭니다.
2. PC 배경의 우표 패턴 계산에서 `window.innerHeight`으로 계산합니다.
3. 자잘한 style을 수정합니다.