### PR TITLE
react-google-logout 구글 로그아웃 실패 시에도 쿠키는 만료처리되도록 수정

### DIFF
--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,6 +1,7 @@
 import {useGoogleLogout} from 'react-google-login'
 import {GOOGLE} from '$config'
 import {withAxios} from '$utils/fetcher/withAxios'
+import {noop} from '$utils/index'
 
 const useLogout = (isGoogleLogin: boolean) => {
     const requestLogout = async () => {
@@ -11,7 +12,7 @@ const useLogout = (isGoogleLogin: boolean) => {
 
     const {signOut} = useGoogleLogout({
         clientId: GOOGLE.CLIENT_ID,
-        onLogoutSuccess: requestLogout,
+        onLogoutSuccess: noop,
         onFailure: () => {
             console.error('구글 계정 로그아웃에 실패했습니다.')
         },
@@ -20,8 +21,8 @@ const useLogout = (isGoogleLogin: boolean) => {
     return () => {
         if (isGoogleLogin) {
             signOut()
-            return
         }
+
         requestLogout()
     }
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -6,6 +6,17 @@ export default class CustomDocument extends Document {
         return (
             <Html lang="ko">
                 <Head>
+                    <script async src="https://www.googletagmanager.com/gtag/js?id=G-L9C81HMX88"></script>
+                    <script
+                        dangerouslySetInnerHTML={{
+                            __html: `
+                                window.dataLayer = window.dataLayer || [];
+                                function gtag(){dataLayer.push(arguments);}
+                                gtag('js', new Date());
+
+                                gtag('config', 'G-L9C81HMX88');
+                            `,
+                        }}></script>
                     <meta charSet="utf-8" />
                     <link
                         rel="preload"


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#161

### 작업 분류

-   [X] 버그 수정
-   [ ] 신규 기능
-   [ ] 프로젝트 구조 변경

### 작업 상세 내용
정상플로우 : 로그인 토큰 만료된 경우 로그아웃되었다 안내 되고 쿠키 삭제 -> 로그인화면 이동
현재 : react-google-login 에서 처리하는 구글로그아웃 실패시 서비스 내 쿠키삭제로직이 호출되지 않도록 되어있어 구글로그아웃 성공/실패여부와 상관없이 쿠키삭제해주도록 처리해주었습니다.
