### PR TITLE
[오류 수정] 프로필 정보 오류 Alert 무한반복 수정

### DIFF
--- a/src/components/main/MainSidebar.tsx
+++ b/src/components/main/MainSidebar.tsx
@@ -7,9 +7,7 @@ import {SidebarButton} from '$components/main/types'
 import {useProfileContext} from '$contexts/ProfileContext'
 import LoginedWelcomeArea from '$components/main/LoginedWelcomeArea'
 import {EXTERNAL_URL} from '$constants'
-import {useAlertStore} from '$contexts/StoreContext'
-import {useEffect} from 'react'
-import {useRouter} from 'next/router'
+import useProfileError from '$hooks/useProfileError'
 
 const SidebarContainer = styled.div`
     padding: 3.2rem 0;
@@ -23,9 +21,9 @@ type MainSidebarProps = {
 }
 
 const MainSidebar = ({isShow, logined, closeFn, logout}: MainSidebarProps) => {
-    const {profile, error} = useProfileContext()
-    const {alert} = useAlertStore()
-    const router = useRouter()
+    const {profile} = useProfileContext()
+    useProfileError(() => logout(false))
+
     const logoutValue: SidebarButton[] = logined
         ? [
               {
@@ -41,22 +39,6 @@ const MainSidebar = ({isShow, logined, closeFn, logout}: MainSidebarProps) => {
               },
           ]
         : []
-
-    useEffect(() => {
-        if (error) {
-            logout(false)
-            alert({
-                title: `로그아웃되었어.\n다시 로그인해줄래?`,
-                successText: '다시 로그인할래',
-                onSuccess: () => {
-                    router.replace(ROUTES.LOGIN)
-                },
-                onClose: () => {
-                    router.replace(ROUTES.LOGIN)
-                },
-            })
-        }
-    }, [error])
 
     return (
         <Sidebar isShow={isShow} closeFn={closeFn}>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,7 +1,9 @@
 import {ResponseCode} from 'types/response'
 import {StickerType} from '$types/response/letter'
 
-export const RESPONSE: {[key in string]: ResponseCode} = {
+type ResponseType = 'NORMAL' | 'ERROR' | 'REDIRECT' | 'INVALID_ACCESS_TOKEN'
+
+export const RESPONSE: {[key in ResponseType]: ResponseCode} = {
     NORMAL: '00',
     ERROR: '99',
     REDIRECT: '01',

--- a/src/hooks/useProfileError.ts
+++ b/src/hooks/useProfileError.ts
@@ -1,0 +1,30 @@
+import {useProfileContext} from '$contexts/ProfileContext'
+import {useAlertStore} from '$contexts/StoreContext'
+import {useEffect} from 'react'
+import ROUTES from '$constants/routes'
+import {useRouter} from 'next/router'
+
+const useProfileError = (callback: (...args: unknown[]) => void) => {
+    const {error} = useProfileContext()
+    const {alert} = useAlertStore()
+    const router = useRouter()
+
+    useEffect(() => {
+        if (error) {
+            alert({
+                title: `로그아웃되었어.\n다시 로그인해줄래?`,
+                successText: '다시 로그인할래',
+                onSuccess: () => {
+                    callback()
+                    router.replace(ROUTES.LOGIN)
+                },
+                onClose: () => {
+                    callback()
+                    router.replace(ROUTES.LOGIN)
+                },
+            })
+        }
+    }, [error])
+}
+
+export default useProfileError

--- a/src/hooks/useProfileError.ts
+++ b/src/hooks/useProfileError.ts
@@ -1,6 +1,6 @@
 import {useProfileContext} from '$contexts/ProfileContext'
 import {useAlertStore} from '$contexts/StoreContext'
-import {useEffect} from 'react'
+import {useEffect, useState} from 'react'
 import ROUTES from '$constants/routes'
 import {useRouter} from 'next/router'
 
@@ -9,8 +9,16 @@ const useProfileError = (callback: (...args: unknown[]) => void) => {
     const {alert} = useAlertStore()
     const router = useRouter()
 
+    const [localError, setLocalError] = useState<Error | undefined>()
+
     useEffect(() => {
-        if (error) {
+        setLocalError(error)
+    }, [error])
+
+    useEffect(() => {
+        if (localError) {
+            setLocalError(undefined)
+
             alert({
                 title: `로그아웃되었어.\n다시 로그인해줄래?`,
                 successText: '다시 로그인할래',
@@ -24,7 +32,7 @@ const useProfileError = (callback: (...args: unknown[]) => void) => {
                 },
             })
         }
-    }, [error])
+    }, [localError])
 }
 
 export default useProfileError

--- a/src/pages/api/letters/[encryptedId]/index.ts
+++ b/src/pages/api/letters/[encryptedId]/index.ts
@@ -17,7 +17,7 @@ const getLetter = async (req: NextApiRequest, res: NextApiResponse<Response<Lett
         }
 
         res.status(200).json({
-            code: RESPONSE.NORAML,
+            code: RESPONSE.NORMAL,
             message: '',
             result: letter,
         })

--- a/src/pages/api/letters/[encryptedId]/state.ts
+++ b/src/pages/api/letters/[encryptedId]/state.ts
@@ -8,24 +8,22 @@ import {API_URL_BASE} from '$config'
 /**
  * 편지 읽음 처리
  */
-export default async function handler(
-    req: NextApiRequest,
-    res: NextApiResponse<Response<Letter | null>>
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse<Response<Letter | null>>) {
     const {encryptedId} = req.query
     try {
-        const {data: {errorCode, message, data: updatedLetter}}: AxiosResponse<ServerResponse<Letter>> = await axios.put(`${API_URL_BASE}/letters/${encryptedId}/state`)
+        const {
+            data: {errorCode, message, data: updatedLetter},
+        }: AxiosResponse<ServerResponse<Letter>> = await axios.put(`${API_URL_BASE}/letters/${encryptedId}/state`)
         if (errorCode) {
             console.info(`errorCode: ${errorCode}, message: ${message}`)
             throw new Error(message)
         }
 
         res.status(200).json({
-            code: RESPONSE.NORAML,
+            code: RESPONSE.NORMAL,
             message: '',
             result: updatedLetter,
         })
-
     } catch (e) {
         res.status(500).json({
             code: RESPONSE.ERROR,

--- a/src/pages/api/letters/index.ts
+++ b/src/pages/api/letters/index.ts
@@ -20,7 +20,7 @@ const listLetters = async (req: NextApiRequest, res: NextApiResponse<Response<Le
         }
 
         res.status(200).json({
-            code: RESPONSE.NORAML,
+            code: RESPONSE.NORMAL,
             message: '',
             result: letters.map((letter) => {
                 return {

--- a/src/pages/api/letters/options/[optionId].ts
+++ b/src/pages/api/letters/options/[optionId].ts
@@ -30,7 +30,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         const questionArr = [...questionByOption, ...commonQuestion]
 
         res.status(200).json({
-            code: RESPONSE.NORAML,
+            code: RESPONSE.NORMAL,
             message: '',
             result: {
                 ...questionArr,

--- a/src/pages/api/letters/options/index.ts
+++ b/src/pages/api/letters/options/index.ts
@@ -20,7 +20,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         const filteredOptions: LetterOption[] = options.filter((option) => option.id < 6)
 
         res.status(200).json({
-            code: RESPONSE.NORAML,
+            code: RESPONSE.NORMAL,
             message: '',
             result: filteredOptions,
         })

--- a/src/pages/api/mail/[sendOptionId].ts
+++ b/src/pages/api/mail/[sendOptionId].ts
@@ -23,7 +23,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
         }
 
         res.status(200).json({
-            code: RESPONSE.NORAML,
+            code: RESPONSE.NORMAL,
             message: '',
             result: null,
         })

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,1 +1,5 @@
+import {NEXT_PUBLIC_ENV} from '$config/index'
+
 export const isSSR = typeof window === 'undefined'
+
+export const isLocalEnv = NEXT_PUBLIC_ENV === 'local'


### PR DESCRIPTION
### 이슈 번호

Nexters/covid-letter-web#170

### 작업 분류

-   [x] 버그 수정
-   [ ] 신규 기능
-   [ ] 프로젝트 구조 변경

### 작업 상세 내용

`/profile` 오류 발생 시, 오류 Alert가 무한 반복되는 현상을 수정합니다.

- swr에서 오는 에러를 사용하지 않고 localError state를 사용합니다.
- `RESPONSE`의 key 타입을 추가하였습니다. (진즉 추가했어야 했는데 죄송합니다 ㅠㅠ 직접 입력하시느라 힘드셨져..ㅠ)
